### PR TITLE
Refactor useChastity state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 // src/App.jsx
 import React, { useState, Suspense, lazy } from 'react';
-import { useChastityOS } from './hooks/useChastityOS'; // Import the new hook
+import { useChastityState } from './hooks/useChastityState';
 import MainNav from './components/MainNav';
 import FooterNav from './components/FooterNav';
 import HotjarScript from './components/HotjarScript';
@@ -16,7 +16,7 @@ const App = () => {
     const [currentPage, setCurrentPage] = useState('tracker');
     
     // Get all state and logic from the custom hook
-    const chastityOS = useChastityOS();
+    const chastityOS = useChastityState();
 
     const { 
         isLoading, 

--- a/src/components/settings/AccountSection.jsx
+++ b/src/components/settings/AccountSection.jsx
@@ -25,7 +25,7 @@ const AccountSection = ({
     
     try {
       await signInWithPopup(auth, provider);
-      // The onAuthStateChanged listener in useChastityOS will handle the rest.
+      // The onAuthStateChanged listener in useChastityState will handle the rest.
     } catch (error) {
       console.error('❌ Google Sign-In Error:', error);
       if (error.code !== 'auth/popup-closed-by-user') {

--- a/src/hooks/chastity/keyholderHandlers.js
+++ b/src/hooks/chastity/keyholderHandlers.js
@@ -1,0 +1,102 @@
+import { useCallback } from 'react';
+import { generateHash } from '../../utils/hash';
+
+export function useKeyholderHandlers(options) {
+    const {
+        userId,
+        saveDataToFirestore,
+        setKeyholderName,
+        setKeyholderPasswordHash,
+        setRequiredKeyholderDurationSeconds,
+        setIsKeyholderModeUnlocked,
+        setKeyholderMessage,
+        setGoalDurationSeconds,
+        keyholderPasswordHash,
+        keyholderName
+    } = options;
+
+    const handleSetKeyholder = useCallback(async (name) => {
+        if (!userId) {
+            setKeyholderMessage('Error: User ID not available.');
+            return null;
+        }
+        const khName = name.trim();
+        if (!khName) {
+            setKeyholderMessage('Keyholder name cannot be empty.');
+            return null;
+        }
+        const hash = await generateHash(userId + khName);
+        if (!hash) {
+            setKeyholderMessage('Error generating Keyholder ID.');
+            return null;
+        }
+        setKeyholderName(khName);
+        setKeyholderPasswordHash(hash);
+        setRequiredKeyholderDurationSeconds(null);
+        setIsKeyholderModeUnlocked(false);
+        await saveDataToFirestore({ keyholderName: khName, keyholderPasswordHash: hash, requiredKeyholderDurationSeconds: null });
+        setKeyholderMessage(`Keyholder "${khName}" set. Password preview generated.`);
+        return hash.substring(0, 8).toUpperCase();
+    }, [userId, saveDataToFirestore]);
+
+    const handleClearKeyholder = useCallback(async () => {
+        setKeyholderName('');
+        setKeyholderPasswordHash(null);
+        setRequiredKeyholderDurationSeconds(null);
+        setIsKeyholderModeUnlocked(false);
+        await saveDataToFirestore({ keyholderName: '', keyholderPasswordHash: null, requiredKeyholderDurationSeconds: null });
+        setKeyholderMessage('Keyholder data cleared.');
+    }, [saveDataToFirestore]);
+
+    const handleUnlockKeyholderControls = useCallback(async (enteredPasswordPreview) => {
+        if (!userId || !keyholderName || !keyholderPasswordHash) {
+            setKeyholderMessage('Keyholder not fully set up.');
+            return false;
+        }
+        const expectedPreview = keyholderPasswordHash.substring(0, 8).toUpperCase();
+        if (enteredPasswordPreview.toUpperCase() === expectedPreview) {
+            setIsKeyholderModeUnlocked(true);
+            setKeyholderMessage('Keyholder controls unlocked.');
+            return true;
+        }
+        setIsKeyholderModeUnlocked(false);
+        setKeyholderMessage('Incorrect Keyholder password.');
+        return false;
+    }, [userId, keyholderName, keyholderPasswordHash]);
+
+    const handleLockKeyholderControls = useCallback(() => {
+        setIsKeyholderModeUnlocked(false);
+        setKeyholderMessage('Keyholder controls locked.');
+    }, []);
+
+    const handleSetRequiredDuration = useCallback(async (durationInSeconds) => {
+        const newDuration = Number(durationInSeconds);
+        if (!isNaN(newDuration) && newDuration >= 0) {
+            setRequiredKeyholderDurationSeconds(newDuration);
+            await saveDataToFirestore({ requiredKeyholderDurationSeconds: newDuration });
+            setKeyholderMessage('Required duration updated.');
+            return true;
+        }
+        setKeyholderMessage('Invalid duration value.');
+        return false;
+    }, [saveDataToFirestore]);
+
+    const handleSetGoalDuration = useCallback(async (newDurationInSeconds) => {
+        const newDuration = newDurationInSeconds === null ? null : Number(newDurationInSeconds);
+        if (newDuration === null || (!isNaN(newDuration) && newDuration >= 0)) {
+            setGoalDurationSeconds(newDuration);
+            await saveDataToFirestore({ goalDurationSeconds: newDuration });
+            return true;
+        }
+        return false;
+    }, [saveDataToFirestore]);
+
+    return {
+        handleSetKeyholder,
+        handleClearKeyholder,
+        handleUnlockKeyholderControls,
+        handleLockKeyholderControls,
+        handleSetRequiredDuration,
+        handleSetGoalDuration
+    };
+}

--- a/src/utils/hash.js
+++ b/src/utils/hash.js
@@ -1,0 +1,13 @@
+export async function generateHash(text) {
+    if (!text) return null;
+    try {
+        const encoder = new TextEncoder();
+        const data = encoder.encode(text);
+        const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+    } catch (error) {
+        console.error('Error generating hash:', error);
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- rename `useChastityOS` to `useChastityState`
- split out keyholder logic into its own handler module
- move `generateHash` helper to `utils`
- update imports across the app

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845faa441a4832c8f49c56cb8957918