### PR TITLE
Fix keyholder password preview

### DIFF
--- a/src/components/settings/KeyholderSection.jsx
+++ b/src/components/settings/KeyholderSection.jsx
@@ -4,6 +4,7 @@ import { formatElapsedTime } from '../../utils';
 
 const KeyholderSection = ({
   keyholderName,
+  keyholderPasswordHash,
   handleSetKeyholder,
   handleClearKeyholder,
   handleUnlockKeyholderControls,
@@ -19,6 +20,7 @@ const KeyholderSection = ({
   const [khRequiredDurationDays, setKhRequiredDurationDays] = useState('');
   const [khRequiredDurationHours, setKhRequiredDurationHours] = useState('');
   const [khRequiredDurationMinutes, setKhRequiredDurationMinutes] = useState('');
+  const passwordPreview = keyholderPasswordHash ? keyholderPasswordHash.substring(0, 8).toUpperCase() : '';
 
   useEffect(() => {
     if (requiredKeyholderDurationSeconds) {
@@ -65,6 +67,9 @@ const KeyholderSection = ({
           <p className="text-purple-300 mb-2">Keyholder: <strong>{keyholderName}</strong></p>
           {!isKeyholderModeUnlocked ? (
             <>
+              {passwordPreview && (
+                <p className="text-purple-400 mb-2 text-sm">Password Preview: <code>{passwordPreview}</code></p>
+              )}
               <input type="text" maxLength={8} value={khPasswordInput} onChange={e => setKhPasswordInput(e.target.value)} placeholder="Enter Password Preview"
                 className="w-full px-3 py-2 mb-3 rounded border border-pink-600 bg-gray-900 text-white" />
               <button onClick={onUnlockControls} className="bg-pink-500 hover:bg-pink-600 text-white px-4 py-2 rounded">Unlock Controls</button>

--- a/src/hooks/chastity/keyholderHandlers.js
+++ b/src/hooks/chastity/keyholderHandlers.js
@@ -35,8 +35,9 @@ export function useKeyholderHandlers(options) {
         setRequiredKeyholderDurationSeconds(null);
         setIsKeyholderModeUnlocked(false);
         await saveDataToFirestore({ keyholderName: khName, keyholderPasswordHash: hash, requiredKeyholderDurationSeconds: null });
-        setKeyholderMessage(`Keyholder "${khName}" set. Password preview generated.`);
-        return hash.substring(0, 8).toUpperCase();
+        const preview = hash.substring(0, 8).toUpperCase();
+        setKeyholderMessage(`Keyholder "${khName}" set. Password preview: ${preview}`);
+        return preview;
     }, [userId, saveDataToFirestore]);
 
     const handleClearKeyholder = useCallback(async () => {

--- a/src/hooks/useChastityState.js
+++ b/src/hooks/useChastityState.js
@@ -7,7 +7,6 @@ import {
     collection, addDoc, query, orderBy, getDocs, serverTimestamp, deleteDoc, onSnapshot
 } from 'firebase/firestore';
 import { formatTime, formatElapsedTime } from '../utils';
-import { generateHash } from '../utils/hash';
 import { useKeyholderHandlers } from './chastity/keyholderHandlers';
 
 const firebaseConfig = {
@@ -556,7 +555,7 @@ export const useChastityState = () => {
         lastPauseEndTime, setLastPauseEndTime,
         pauseCooldownMessage, setPauseCooldownMessage, showRestoreSessionPrompt, setShowRestoreSessionPrompt,
         loadedSessionData, hasSessionEverBeenActive,
-        goalDurationSeconds, keyholderName,
+        goalDurationSeconds, keyholderName, keyholderPasswordHash,
         isKeyholderModeUnlocked, requiredKeyholderDurationSeconds,
         keyholderMessage, setKeyholderMessage, editSessionDateInput, setEditSessionDateInput,
         editSessionTimeInput, setEditSessionTimeInput, editSessionMessage,


### PR DESCRIPTION
## Summary
- include password preview in keyholder message
- display preview in settings page
- return keyholderPasswordHash from hook
- remove unused `generateHash` import

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846fe851b78832c86c02a2d01bd4c78