### PR TITLE
Add keyholder page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import HotjarScript from './components/HotjarScript';
 const TrackerPage = lazy(() => import('./pages/TrackerPage'));
 const FullReportPage = lazy(() => import('./pages/FullReportPage'));
 const LogEventPage = lazy(() => import('./pages/LogEventPage'));
+const KeyholderPage = lazy(() => import('./pages/KeyholderPage'));
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 const FeedbackForm = lazy(() => import('./pages/FeedbackForm'));
 const PrivacyPage = lazy(() => import('./pages/PrivacyPage'));
@@ -28,7 +29,7 @@ const App = () => {
     } = chastityOS;
 
     let pageTitleText = "ChastityOS";
-    const navItemNames = { tracker: "Chastity Tracker", logEvent: "Sexual Event Log", fullReport: "Full Report", settings: "Settings", privacy: "Privacy & Analytics", feedback: "Submit Beta Feedback" };
+    const navItemNames = { tracker: "Chastity Tracker", logEvent: "Sexual Event Log", fullReport: "Full Report", keyholder: "Keyholder Mode", settings: "Settings", privacy: "Privacy & Analytics", feedback: "Submit Beta Feedback" };
     if (currentPage === 'tracker' && showRestoreSessionPrompt) {
         pageTitleText = "Restore Session";
     } else if (navItemNames[currentPage]) {
@@ -58,6 +59,7 @@ const App = () => {
                     {currentPage === 'tracker' && <TrackerPage {...chastityOS} />}
                     {currentPage === 'fullReport' && <FullReportPage {...chastityOS} />}
                     {currentPage === 'logEvent' && <LogEventPage {...chastityOS} />}
+                    {currentPage === 'keyholder' && <KeyholderPage {...chastityOS} />}
                     {currentPage === 'settings' && <SettingsPage {...chastityOS} setCurrentPage={setCurrentPage} />}
                     {currentPage === 'privacy' && <PrivacyPage onBack={() => setCurrentPage('settings')} />}
                     {currentPage === 'feedback' && <FeedbackForm onBack={() => setCurrentPage('settings')} userId={userId} />}

--- a/src/components/MainNav.jsx
+++ b/src/components/MainNav.jsx
@@ -6,6 +6,7 @@ const MainNav = ({ currentPage, setCurrentPage }) => {
     { id: 'tracker', name: 'Chastity Tracker' },
     { id: 'logEvent', name: 'Log Event' },
     { id: 'fullReport', name: 'Full Report' },
+    { id: 'keyholder', name: 'Keyholder Mode' },
     { id: 'settings', name: 'Settings' },
     // { id: 'privacy', name: 'Privacy' }, // Privacy removed from main navigation
     { id: 'feedback', name: 'Feedback' }

--- a/src/pages/KeyholderPage.jsx
+++ b/src/pages/KeyholderPage.jsx
@@ -1,0 +1,11 @@
+// src/pages/KeyholderPage.jsx
+import React from 'react';
+import KeyholderSection from '../components/settings/KeyholderSection';
+
+const KeyholderPage = (props) => (
+  <div className="p-0 md:p-4">
+    <KeyholderSection {...props} />
+  </div>
+);
+
+export default KeyholderPage;

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,7 +1,6 @@
 // src/pages/SettingsPage.jsx
 import React from 'react';
 import AccountSection from '../components/settings/AccountSection';
-import KeyholderSection from '../components/settings/KeyholderSection';
 import DataManagementSection from '../components/settings/DataManagementSection';
 import SessionEditSection from '../components/settings/SessionEditSection';
 
@@ -12,7 +11,6 @@ const SettingsPage = (props) => {
   return (
     <div className="p-0 md:p-4">
       <AccountSection {...props} />
-      <KeyholderSection {...props} />
       <DataManagementSection {...props} />
       <SessionEditSection {...props} />
     </div>


### PR DESCRIPTION
## Summary
- make `KeyholderPage` to hold keyholder-related settings
- remove keyholder section from SettingsPage
- add new "Keyholder Mode" page to the main nav and app routing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684701ea576c832cac584dee39811b43