### PR TITLE
Fix keyholder password preview message

### DIFF
--- a/src/hooks/chastity/keyholderHandlers.js
+++ b/src/hooks/chastity/keyholderHandlers.js
@@ -35,8 +35,9 @@ export function useKeyholderHandlers(options) {
         setRequiredKeyholderDurationSeconds(null);
         setIsKeyholderModeUnlocked(false);
         await saveDataToFirestore({ keyholderName: khName, keyholderPasswordHash: hash, requiredKeyholderDurationSeconds: null });
-        setKeyholderMessage(`Keyholder "${khName}" set. Password preview generated.`);
-        return hash.substring(0, 8).toUpperCase();
+        const preview = hash.substring(0, 8).toUpperCase();
+        setKeyholderMessage(`Keyholder "${khName}" set. Password preview: ${preview}`);
+        return preview;
     }, [userId, saveDataToFirestore]);
 
     const handleClearKeyholder = useCallback(async () => {


### PR DESCRIPTION
## Summary
- show generated password preview when setting keyholder

## Testing
- `npm run lint` *(fails: cannot find package @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68470cfabe44832caf9c09d9feb9a295