### PR TITLE
Move keyholder features to dedicated page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ const TrackerPage = lazy(() => import('./pages/TrackerPage'));
 const FullReportPage = lazy(() => import('./pages/FullReportPage'));
 const LogEventPage = lazy(() => import('./pages/LogEventPage'));
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
+const KeyholderPage = lazy(() => import('./pages/KeyholderPage'));
 const FeedbackForm = lazy(() => import('./pages/FeedbackForm'));
 const PrivacyPage = lazy(() => import('./pages/PrivacyPage'));
 const RewardsPunishmentsPage = lazy(() => import('./pages/RewardsPunishmentsPage'));
@@ -29,7 +30,7 @@ const App = () => {
     } = chastityOS;
 
     let pageTitleText = "ChastityOS";
-    const navItemNames = { tracker: "Chastity Tracker", logEvent: "Sexual Event Log", fullReport: "Full Report", rewards: "Rewards & Punishments", settings: "Settings", privacy: "Privacy & Analytics", feedback: "Submit Beta Feedback" };
+    const navItemNames = { tracker: "Chastity Tracker", logEvent: "Sexual Event Log", fullReport: "Full Report", keyholder: "Keyholder", rewards: "Rewards & Punishments", settings: "Settings", privacy: "Privacy & Analytics", feedback: "Submit Beta Feedback" };
     if (currentPage === 'tracker' && showRestoreSessionPrompt) {
         pageTitleText = "Restore Session";
     } else if (navItemNames[currentPage]) {
@@ -59,6 +60,7 @@ const App = () => {
                     {currentPage === 'tracker' && <TrackerPage {...chastityOS} />}
                     {currentPage === 'fullReport' && <FullReportPage {...chastityOS} />}
                     {currentPage === 'logEvent' && <LogEventPage {...chastityOS} />}
+                    {currentPage === 'keyholder' && <KeyholderPage {...chastityOS} />}
                     {currentPage === 'rewards' && <RewardsPunishmentsPage {...chastityOS} />}
                     {currentPage === 'settings' && <SettingsPage {...chastityOS} setCurrentPage={setCurrentPage} />}
                     {currentPage === 'privacy' && <PrivacyPage onBack={() => setCurrentPage('settings')} />}

--- a/src/components/MainNav.jsx
+++ b/src/components/MainNav.jsx
@@ -6,6 +6,7 @@ const MainNav = ({ currentPage, setCurrentPage }) => {
     { id: 'tracker', name: 'Chastity Tracker' },
     { id: 'logEvent', name: 'Log Event' },
     { id: 'fullReport', name: 'Full Report' },
+    { id: 'keyholder', name: 'Keyholder' },
     { id: 'rewards', name: 'Rewards/Punishments' },
     { id: 'settings', name: 'Settings' },
     // { id: 'privacy', name: 'Privacy' }, // Privacy removed from main navigation

--- a/src/pages/KeyholderPage.jsx
+++ b/src/pages/KeyholderPage.jsx
@@ -1,0 +1,13 @@
+// src/pages/KeyholderPage.jsx
+import React from 'react';
+import KeyholderSection from '../components/settings/KeyholderSection';
+
+const KeyholderPage = (props) => {
+  return (
+    <div className="p-0 md:p-4">
+      <KeyholderSection {...props} />
+    </div>
+  );
+};
+
+export default KeyholderPage;

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,7 +1,6 @@
 // src/pages/SettingsPage.jsx
 import React from 'react';
 import AccountSection from '../components/settings/AccountSection';
-import KeyholderSection from '../components/settings/KeyholderSection';
 import DataManagementSection from '../components/settings/DataManagementSection';
 import SessionEditSection from '../components/settings/SessionEditSection';
 
@@ -12,7 +11,6 @@ const SettingsPage = (props) => {
   return (
     <div className="p-0 md:p-4">
       <AccountSection {...props} />
-      <KeyholderSection {...props} />
       <DataManagementSection {...props} />
       <SessionEditSection {...props} />
     </div>


### PR DESCRIPTION
## Summary
- create `KeyholderPage` to host Keyholder controls
- drop Keyholder section from Settings
- add Keyholder page to navigation
- load Keyholder page in App

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847163ee8a8832c95a58d9bbfe6c501