### PR TITLE
Fix full report logs

### DIFF
--- a/src/components/log_event/EventLogTable.jsx
+++ b/src/components/log_event/EventLogTable.jsx
@@ -30,13 +30,27 @@ const EventLogTable = ({ isLoadingEvents, sexualEventsLog, savedSubmissivesName 
                     <th className="px-4 py-2 text-left text-xs font-medium text-purple-300 uppercase">Orgasm Count(s)</th>
                     <th className="px-4 py-2 text-left text-xs font-medium text-purple-300 uppercase">Notes</th>
                 </tr></thead><tbody className="divide-y divide-purple-700">
-                {sexualEventsLog.map(event => (<tr key={event.id} className="hover:bg-purple-900/20">
-                    <td className="px-4 py-3 whitespace-nowrap text-sm text-purple-200">{formatTime(event.eventTimestamp, true)}</td>
-                    <td className="px-4 py-3 text-sm text-purple-200 whitespace-pre-wrap break-words max-w-xs">{formatEventTypesForDisplay(event.types, event.otherTypeDetail, savedSubmissivesName)}</td>
-                    <td className="px-4 py-3 whitespace-nowrap text-sm text-purple-200">{event.durationSeconds ? formatElapsedTime(event.durationSeconds) : 'N/A'}</td>
-                    <td className="px-4 py-3 whitespace-nowrap text-sm text-purple-200">{formatOrgasmCounts(event.selfOrgasmAmount, event.partnerOrgasmAmount)}</td>
-                    <td className="px-4 py-3 text-sm text-purple-200 whitespace-pre-wrap break-words max-w-xs">{event.notes}</td>
-                </tr>))}</tbody></table></div>) : <p className="text-purple-200">No events logged yet.</p>}
+                {sexualEventsLog.map(event => (
+                    event.eventType === 'startTimeEdit' ? (
+                        <tr key={event.id} className="hover:bg-purple-900/20">
+                            <td className="px-4 py-3 whitespace-nowrap text-sm text-purple-200">{formatTime(event.eventTimestamp || event.timestamp, true)}</td>
+                            <td className="px-4 py-3 text-sm text-purple-200">Start Time Edited</td>
+                            <td className="px-4 py-3 whitespace-nowrap text-sm text-purple-200">N/A</td>
+                            <td className="px-4 py-3 whitespace-nowrap text-sm text-purple-200">N/A</td>
+                            <td className="px-4 py-3 text-sm text-purple-200 whitespace-pre-wrap break-words max-w-xs">
+                                {`Old: ${event.oldStartTime ? formatTime(new Date(event.oldStartTime), true) : 'N/A'} \u2192 New: ${event.newStartTime ? formatTime(new Date(event.newStartTime), true) : 'N/A'}${event.editedBy ? ` (by ${event.editedBy})` : ''}`}
+                            </td>
+                        </tr>
+                    ) : (
+                        <tr key={event.id} className="hover:bg-purple-900/20">
+                            <td className="px-4 py-3 whitespace-nowrap text-sm text-purple-200">{formatTime(event.eventTimestamp, true)}</td>
+                            <td className="px-4 py-3 text-sm text-purple-200 whitespace-pre-wrap break-words max-w-xs">{formatEventTypesForDisplay(event.types, event.otherTypeDetail, savedSubmissivesName)}</td>
+                            <td className="px-4 py-3 whitespace-nowrap text-sm text-purple-200">{event.durationSeconds ? formatElapsedTime(event.durationSeconds) : 'N/A'}</td>
+                            <td className="px-4 py-3 whitespace-nowrap text-sm text-purple-200">{formatOrgasmCounts(event.selfOrgasmAmount, event.partnerOrgasmAmount)}</td>
+                            <td className="px-4 py-3 text-sm text-purple-200 whitespace-pre-wrap break-words max-w-xs">{event.notes}</td>
+                        </tr>
+                    )
+                ))}</tbody></table></div>) : <p className="text-purple-200">No events logged yet.</p>}
         </div>
     );
 };

--- a/src/components/settings/SessionEditSection.jsx
+++ b/src/components/settings/SessionEditSection.jsx
@@ -76,7 +76,8 @@ const SessionEditSection = ({
         oldStartTime,
         newStartTime: newStartDateTime.toISOString(),
         editedBy: userId ?? 'unknown',
-        timestamp: serverTimestamp()
+        timestamp: serverTimestamp(),
+        eventTimestamp: serverTimestamp()
       });
 
       setEditSessionMessage('Start time updated successfully.');

--- a/src/hooks/useChastityState.js
+++ b/src/hooks/useChastityState.js
@@ -170,7 +170,12 @@ export const useChastityState = () => {
         try {
             const q = query(eventsColRef, orderBy("eventTimestamp", "desc"));
             const querySnapshot = await getDocs(q);
-            setSexualEventsLog(querySnapshot.docs.map(d => ({ id: d.id, ...d.data(), eventTimestamp: d.data().eventTimestamp?.toDate() })));
+            setSexualEventsLog(querySnapshot.docs.map(d => ({
+                id: d.id,
+                ...d.data(),
+                eventTimestamp: d.data().eventTimestamp?.toDate() || d.data().timestamp?.toDate(),
+                timestamp: d.data().timestamp?.toDate()
+            })));
         } catch (error) { console.error("Error fetching events:", error); setEventLogMessage("Failed to load events."); setTimeout(() => setEventLogMessage(''), 3000);
         } finally { setIsLoadingEvents(false); }
     }, [isAuthReady, userId, getEventsCollectionRef]);

--- a/src/pages/FullReportPage.jsx
+++ b/src/pages/FullReportPage.jsx
@@ -3,8 +3,7 @@ import React from 'react';
 import CurrentStatusSection from '../components/full_report/CurrentStatusSection';
 import TotalsSection from '../components/full_report/TotalsSection';
 import ChastityHistoryTable from '../components/full_report/ChastityHistoryTable';
-import SexualEventsLogSection from '../components/full_report/SessionEventLogSection';
-import SessionEventLogSection from '../components/full_report/SessionEventLogSection';
+import EventLogTable from '../components/log_event/EventLogTable';
 
 const FullReportPage = ({
     savedSubmissivesName, userId, isCageOn, cageOnTime, timeInChastity, timeCageOff,
@@ -52,16 +51,10 @@ const FullReportPage = ({
             <hr className="my-3 border-purple-700"/>
 
             <h3 className="text-xl font-semibold text-purple-300 mt-4 mb-2 text-center">Sexual Events Log</h3>
-            <SexualEventsLogSection
+            <EventLogTable
                 isLoadingEvents={isLoadingEvents}
                 sexualEventsLog={sexualEventsLog}
                 savedSubmissivesName={savedSubmissivesName}
-                keyholderName={keyholderName}
-            />
-            <h3 className="text-xl font-semibold text-orange-300 mt-8 mb-2 text-center">Session Event Log</h3>
-            <SessionEventLogSection
-              isLoadingEvents={isLoadingEvents}
-              eventLog={sexualEventsLog}
             />
         </div>
     );


### PR DESCRIPTION
## Summary
- include start time edits in sexual event table
- log start time edits with an `eventTimestamp`
- show edits in the main event log table
- drop session log section from the report

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481af89c08832c8e0c68603ccf68ca