### PR TITLE
Add console version log

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,6 +9,8 @@ import { HelmetProvider } from 'react-helmet-async';
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
 const environment = import.meta.env.VITE_APP_VARIANT || 'production';
 const sentryProject = import.meta.env.VITE_SENTRY_PROJECT;
+const appVersion = import.meta.env.VITE_APP_VERSION || 'dev';
+console.log(`[ChastityOS] Version: ${appVersion}`);
 
 // Only initialize Sentry if a DSN is provided
 if (sentryDsn) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,11 +3,16 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { VitePWA } from 'vite-plugin-pwa';
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
 
 export default defineConfig(({ mode }) => {
   // Load variables from the correct .env file for the current mode
   // The third argument ('') ensures all variables are loaded, not just VITE_ prefixed ones.
   const env = loadEnv(mode, process.cwd(), '');
+
+  const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'));
+  const appVersion = packageJson.version;
 
   let gitHash = 'dev';
   try {
@@ -29,6 +34,7 @@ export default defineConfig(({ mode }) => {
       // We don't need to define VITE_SENTRY_DSN here again if main.jsx is already reading it,
       // but being explicit helps prevent issues.
       'import.meta.env.VITE_SENTRY_DSN': JSON.stringify(env.VITE_SENTRY_DSN),
+      'import.meta.env.VITE_APP_VERSION': JSON.stringify(appVersion),
     },
     plugins: [
       react(), 


### PR DESCRIPTION
## Summary
- expose `VITE_APP_VERSION` in `vite.config.js`
- log the version in `src/main.jsx` for debugging

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686157a85adc832c8d9262a2b9eaabf9