### PR TITLE
Add Beg for Release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ ChastityOS is a modern chastity and FLR (Female-Led Relationship) tracking web a
 - Keyholder can set a required minimum chastity duration
 - Locked controls unless the user enters the correct 8-character password preview
 - Visual tracker shows progress toward required keyholder time
+- "Beg for Release" button replaces manual unlock when a keyholder lock is active
 
 ### 🎯 Goal Tracking
 - Set a personal chastity goal duration (optional)

--- a/src/components/keyholder/KeyholderDashboard.jsx
+++ b/src/components/keyholder/KeyholderDashboard.jsx
@@ -21,7 +21,10 @@ const KeyholderDashboard = ({
   handleAddPunishment,
   handleAddTask,
   handleApproveTask,
-  handleRejectTask
+  handleRejectTask,
+  releaseRequests = [],
+  handleGrantReleaseRequest,
+  handleDenyReleaseRequest
 }) => {
   const [khNameInput, setKhNameInput] = useState('');
   const [khPasswordInput, setKhPasswordInput] = useState('');
@@ -151,6 +154,21 @@ const KeyholderDashboard = ({
                 <TaskApprovalSection tasks={tasks} onApprove={handleApproveTask} onReject={handleRejectTask} />
                 {/* THE FIX: `onAddTask` now correctly calls `handleAddTask` from props */}
                 <KeyholderAddTaskForm onAddTask={handleAddTask} />
+
+                {releaseRequests.filter(r => r.status === 'pending').length > 0 && (
+                  <div className="mt-6 space-y-3">
+                    <h4 className="title-purple !text-purple-300">Release Requests</h4>
+                    {releaseRequests.filter(r => r.status === 'pending').map(req => (
+                      <div key={req.id} className="flex justify-between items-center p-2 border border-purple-700 rounded-md">
+                        <span className="text-sm">{req.submittedAt ? req.submittedAt.toLocaleString() : ''}</span>
+                        <div className="flex gap-2">
+                          <button onClick={() => handleGrantReleaseRequest(req.id)} className="button-green !text-green-300 px-2">Grant</button>
+                          <button onClick={() => handleDenyReleaseRequest(req.id)} className="button-red !text-red-300 px-2">Deny</button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             )}
           </>

--- a/src/hooks/useReleaseRequests.js
+++ b/src/hooks/useReleaseRequests.js
@@ -1,0 +1,75 @@
+import { useState, useEffect, useCallback } from 'react';
+import { collection, query, onSnapshot, addDoc, updateDoc, deleteDoc, doc, serverTimestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export function useReleaseRequests(userId, isAuthReady) {
+  const [releaseRequests, setReleaseRequests] = useState([]);
+
+  const getCollectionRef = useCallback(() => {
+    if (!userId) return null;
+    return collection(db, 'users', userId, 'releaseRequests');
+  }, [userId]);
+
+  useEffect(() => {
+    if (!isAuthReady || !userId) {
+      setReleaseRequests([]);
+      return;
+    }
+
+    const colRef = getCollectionRef();
+    if (!colRef) return;
+
+    const q = query(colRef);
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const data = snapshot.docs.map(d => {
+        const item = d.data();
+        return {
+          id: d.id,
+          ...item,
+          submittedAt: item.submittedAt && typeof item.submittedAt.toDate === 'function'
+            ? item.submittedAt.toDate()
+            : null,
+        };
+      });
+      setReleaseRequests(data);
+    }, (error) => {
+      console.error('Error fetching release requests:', error);
+    });
+
+    return () => unsubscribe();
+  }, [isAuthReady, userId, getCollectionRef]);
+
+  const addReleaseRequest = useCallback(async () => {
+    const colRef = getCollectionRef();
+    if (!colRef) return;
+    try {
+      await addDoc(colRef, { status: 'pending', submittedAt: serverTimestamp() });
+    } catch (error) {
+      console.error('Error adding release request:', error);
+    }
+  }, [getCollectionRef]);
+
+  const updateReleaseRequest = useCallback(async (id, updates) => {
+    const colRef = getCollectionRef();
+    if (!colRef) return;
+    try {
+      const docRef = doc(colRef, id);
+      await updateDoc(docRef, updates);
+    } catch (error) {
+      console.error('Error updating release request:', error);
+    }
+  }, [getCollectionRef]);
+
+  const deleteReleaseRequest = useCallback(async (id) => {
+    const colRef = getCollectionRef();
+    if (!colRef) return;
+    try {
+      const docRef = doc(colRef, id);
+      await deleteDoc(docRef);
+    } catch (error) {
+      console.error('Error deleting release request:', error);
+    }
+  }, [getCollectionRef]);
+
+  return { releaseRequests, addReleaseRequest, updateReleaseRequest, deleteReleaseRequest };
+}

--- a/src/pages/TrackerPage.jsx
+++ b/src/pages/TrackerPage.jsx
@@ -34,7 +34,9 @@ const TrackerPage = (props) => {
         totalTimeCageOff,
         timeCageOff,
         pauseStartTime,
-        accumulatedPauseTimeThisSession
+        accumulatedPauseTimeThisSession,
+        releaseRequests = [],
+        addReleaseRequest
     } = props;
 
     // Call the new hook to get all the logic and state for this page
@@ -52,6 +54,14 @@ const TrackerPage = (props) => {
         handleAttemptEmergencyUnlock,
         setShowEmergencyUnlockModal,
     } = useTrackerPage(props); // Pass all props from parent to the hook
+
+    const hasPendingReleaseRequest = releaseRequests.some(r => r.status === 'pending');
+
+    const handleBegForRelease = async () => {
+        if (addReleaseRequest) {
+            await addReleaseRequest();
+        }
+    };
 
     if (!isAuthReady) {
         return (
@@ -173,6 +183,11 @@ const TrackerPage = (props) => {
                   <button type="button" onClick={handleOpenUnlockModal} disabled={!isAuthReady || showRestoreSessionPrompt}
                       className="flex-grow font-bold py-3 px-5 md:py-4 md:px-6 rounded-lg shadow-md transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-opacity-75 text-white disabled:opacity-50 bg-red-700 hover:bg-red-800 focus:ring-red-500 flex items-center justify-center">
                      <FaLock className="mr-2"/> Emergency Unlock
+                  </button>
+              ) : requiredKeyholderDurationSeconds > 0 ? (
+                  <button type="button" onClick={handleBegForRelease} disabled={!isAuthReady || hasPendingReleaseRequest || showRestoreSessionPrompt}
+                      className="flex-grow font-bold py-3 px-5 md:py-4 md:px-6 rounded-lg shadow-md transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-opacity-75 text-white disabled:opacity-50 bg-red-500 hover:bg-red-600 focus:ring-red-400">
+                      {hasPendingReleaseRequest ? 'Request Sent' : 'Beg for Release'}
                   </button>
               ) : (
                   <button type="button" onClick={handleToggleCage} disabled={!isAuthReady || isPaused || showRestoreSessionPrompt}


### PR DESCRIPTION
## Summary
- implement `useReleaseRequests` hook for managing release begs
- integrate requests into global state
- add Beg for Release button when keyholder lock active
- show pending release requests in the Keyholder Dashboard
- document new feature in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686328430c00832c9f75e76c9f8dca54