### PR TITLE
Add age consent welcome modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,8 @@ import HotjarScript from './components/HotjarScript';
 import Header from './components/Header';
 import UpdatePrompt from './components/UpdatePrompt';
 import EulaModal from './components/EulaModal';
+import WelcomeModal from './components/WelcomeModal';
+import { useWelcome } from './hooks/useWelcome';
 
 const TrackerPage = lazy(() => import('./pages/TrackerPage'));
 const FullReportPage = lazy(() => import('./pages/FullReportPage'));
@@ -22,9 +24,12 @@ const TasksPage = lazy(() => import('./pages/TasksPage'));
 const App = () => {
     const [currentPage, setCurrentPage] = useState('tracker');
     const [showEulaModal, setShowEulaModal] = useState(false);
-    
-    // chastityOS now contains everything, including task data and handlers
+
+    // chastityOS contains all state, including task data and handlers
     const chastityOS = useChastityState();
+
+    const welcomeState = useWelcome(chastityOS.userId, chastityOS.isAuthReady);
+    const { hasAccepted, isLoading: welcomeLoading, accept } = welcomeState;
     
     // Destructure everything needed for this component's logic
     const { 
@@ -50,7 +55,7 @@ const App = () => {
     const isNightly = import.meta.env.VITE_APP_VARIANT === 'nightly';
     const themeClass = isNightly ? 'theme-nightly' : 'theme-prod';
     
-    if (isLoading) {
+    if (isLoading || welcomeLoading) {
       return <div className="loading-fullscreen">Loading...</div>;
     }
 
@@ -93,6 +98,11 @@ const App = () => {
             <FooterNav userId={userId} googleEmail={googleEmail} onShowEula={() => setShowEulaModal(true)} />
 
             <EulaModal isOpen={showEulaModal} onClose={() => setShowEulaModal(false)} />
+            <WelcomeModal
+              isOpen={!hasAccepted}
+              onAccept={accept}
+              onShowLegal={() => setShowEulaModal(true)}
+            />
         </div>
     );
 };

--- a/src/components/WelcomeModal.jsx
+++ b/src/components/WelcomeModal.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+const HOW_TO_URL = 'https://github.com/thef4tdaddy/chastityOS#readme';
+
+const WelcomeModal = ({ isOpen, onAccept, onShowLegal }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50 p-4">
+      <div className="bg-gray-800 p-6 md:p-8 rounded-xl shadow-2xl w-full max-w-md border-2 border-purple-700 text-gray-200 text-center">
+        <h2 className="text-xl font-bold text-purple-300 mb-4">Welcome to ChastityOS</h2>
+        <p className="mb-2 text-sm">
+          This application is intended for consenting adults <strong>18+</strong> only.
+        </p>
+        <p className="mb-4 text-sm">
+          One shared account is used by both the submissive and keyholder.  Separate accounts will be introduced in the future.
+        </p>
+        <a
+          href={HOW_TO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-purple-300 underline text-sm block mb-2"
+        >
+          How to Use ChastityOS
+        </a>
+        <button
+          type="button"
+          onClick={onShowLegal}
+          className="text-purple-300 underline text-sm mb-4"
+        >
+          View Terms &amp; Disclaimer
+        </button>
+        <button
+          onClick={onAccept}
+          className="mt-2 w-full bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded"
+        >
+          I am 18+ and Accept
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default WelcomeModal;

--- a/src/hooks/useWelcome.js
+++ b/src/hooks/useWelcome.js
@@ -1,0 +1,52 @@
+import { useState, useEffect, useCallback } from 'react';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+/**
+ * Handles showing the welcome modal and persisting acceptance in Firestore.
+ * @param {string} userId - Current user ID.
+ * @param {boolean} isAuthReady - Flag from auth hook.
+ */
+export function useWelcome(userId, isAuthReady) {
+  const [hasAccepted, setHasAccepted] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isAuthReady || !userId) {
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchAcceptance = async () => {
+      const userDocRef = doc(db, 'users', userId);
+      try {
+        const snap = await getDoc(userDocRef);
+        if (snap.exists()) {
+          setHasAccepted(!!snap.data().welcomeAccepted);
+        } else {
+          await setDoc(userDocRef, { welcomeAccepted: false }, { merge: true });
+          setHasAccepted(false);
+        }
+      } catch (err) {
+        console.error('Failed to load acceptance info:', err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchAcceptance();
+  }, [userId, isAuthReady]);
+
+  const accept = useCallback(async () => {
+    if (!isAuthReady || !userId) return;
+    const userDocRef = doc(db, 'users', userId);
+    try {
+      await setDoc(userDocRef, { welcomeAccepted: true }, { merge: true });
+      setHasAccepted(true);
+    } catch (err) {
+      console.error('Failed to record acceptance:', err);
+    }
+  }, [userId, isAuthReady]);
+
+  return { hasAccepted, isLoading, accept };
+}


### PR DESCRIPTION
## Summary
- add hook to store welcome acceptance per user in Firestore
- show modal explaining the app is 18+ with links and Accept button
- note that one account is currently shared by the submissive and keyholder
- record acceptance so returning users no longer see it

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863b0256ffc832c891783107e82a690