### PR TITLE
Add reason categories for pause/removal

### DIFF
--- a/src/components/full_report/TotalsSection.jsx
+++ b/src/components/full_report/TotalsSection.jsx
@@ -2,12 +2,22 @@
 import React from 'react';
 import { formatElapsedTime } from '../../utils';
 
-const TotalsSection = ({ totalChastityTime, totalTimeCageOff, overallTotalPauseTime }) => (
+const TotalsSection = ({ totalChastityTime, totalTimeCageOff, overallTotalPauseTime, pauseReasonTotals }) => (
     <>
         <h3 className="text-xl font-semibold text-purple-300 mb-2">Totals</h3>
         <div className="mb-1"><strong>Total Effective Time In Chastity:</strong> {formatElapsedTime(totalChastityTime)}</div>
         <div className="mb-1"><strong>Total Time Cage Off:</strong> {formatElapsedTime(totalTimeCageOff)}</div>
         <div className="mb-1"><strong>Overall Total Paused Time (from completed sessions):</strong> <span className="text-yellow-300">{formatElapsedTime(overallTotalPauseTime)}</span></div>
+        {pauseReasonTotals && Object.keys(pauseReasonTotals).length > 0 && (
+            <div className="mt-2">
+                <strong>Paused Time by Reason:</strong>
+                <ul className="list-disc list-inside">
+                    {Object.entries(pauseReasonTotals).map(([reason, secs]) => (
+                        <li key={reason}>{reason}: {formatElapsedTime(secs)}</li>
+                    ))}
+                </ul>
+            </div>
+        )}
     </>
 );
 

--- a/src/event_types.js
+++ b/src/event_types.js
@@ -18,3 +18,18 @@ export const EVENT_TYPE_DEFINITIONS = [
     // "Session Edit" is logged programmatically and is not a user option
     { name: "Session Edit", mode: 'vanilla', userSelectable: false }
 ];
+
+// --- New categorized reasons ---
+export const REMOVAL_REASON_OPTIONS = [
+    'Orgasm',
+    'Medical',
+    'Travel',
+    'Other'
+];
+
+export const PAUSE_REASON_OPTIONS = [
+    'Cleaning',
+    'Medical',
+    'Exercise',
+    'Other'
+];

--- a/src/hooks/useChastitySession.js
+++ b/src/hooks/useChastitySession.js
@@ -20,7 +20,7 @@ export const useChastitySession = (
     const [totalTimeCageOff, setTotalTimeCageOff] = useState(0);
     const [overallTotalPauseTime, setOverallTotalPauseTime] = useState(0);
     const [showReasonModal, setShowReasonModal] = useState(false);
-    const [reasonForRemoval, setReasonForRemoval] = useState('');
+    const [reasonForRemoval, setReasonForRemoval] = useState(''); // stores selected removal category
     const [tempEndTime, setTempEndTime] = useState(null);
     const [tempStartTime, setTempStartTime] = useState(null);
     const [showRestoreSessionPrompt, setShowRestoreSessionPrompt] = useState(false);
@@ -37,7 +37,7 @@ export const useChastitySession = (
     const [pauseStartTime, setPauseStartTime] = useState(null);
     const [accumulatedPauseTimeThisSession, setAccumulatedPauseTimeThisSession] = useState(0);
     const [showPauseReasonModal, setShowPauseReasonModal] = useState(false);
-    const [reasonForPauseInput, setReasonForPauseInput] = useState('');
+    const [pauseReason, setPauseReason] = useState(''); // stores selected pause category
     const [currentSessionPauseEvents, setCurrentSessionPauseEvents] = useState([]);
     const [livePauseDuration, setLivePauseDuration] = useState(0);
     const [lastPauseEndTime, setLastPauseEndTime] = useState(null);
@@ -286,12 +286,12 @@ export const useChastitySession = (
         const now = new Date();
         setIsPaused(true);
         setPauseStartTime(now);
-        const updatedPauseEvents = [...currentSessionPauseEvents, { startTime: now, reason: reasonForPauseInput }];
+        const updatedPauseEvents = [...currentSessionPauseEvents, { startTime: now, reason: pauseReason }];
         setCurrentSessionPauseEvents(updatedPauseEvents);
         setShowPauseReasonModal(false);
-        setReasonForPauseInput('');
+        setPauseReason('');
         await saveDataToFirestore({ isPaused: true, pauseStartTime: now, currentSessionPauseEvents: updatedPauseEvents });
-    }, [reasonForPauseInput, saveDataToFirestore, currentSessionPauseEvents]);
+    }, [pauseReason, saveDataToFirestore, currentSessionPauseEvents]);
 
     const handleCancelPauseModal = useCallback(() => setShowPauseReasonModal(false), []);
     
@@ -522,7 +522,7 @@ export const useChastitySession = (
         cageOnTime, isCageOn, timeInChastity, timeCageOff, chastityHistory, totalChastityTime,
         totalTimeCageOff, overallTotalPauseTime, showReasonModal, reasonForRemoval, setReasonForRemoval,
         tempEndTime, tempStartTime, isPaused, pauseStartTime, accumulatedPauseTimeThisSession,
-        showPauseReasonModal, reasonForPauseInput, setReasonForPauseInput, currentSessionPauseEvents,
+        showPauseReasonModal, pauseReason, setPauseReason, currentSessionPauseEvents,
         livePauseDuration, lastPauseEndTime, pauseCooldownMessage, showRestoreSessionPrompt, loadedSessionData,
         hasSessionEverBeenActive, confirmReset, setConfirmReset, editSessionDateInput, setEditSessionDateInput,
         editSessionTimeInput, setEditSessionTimeInput, editSessionMessage, restoreUserIdInput,

--- a/src/pages/FullReportPage.jsx
+++ b/src/pages/FullReportPage.jsx
@@ -17,6 +17,18 @@ const FullReportPage = ({
         ? Math.max(0, timeInChastity - accumulatedPauseTimeThisSession - (isPaused && livePauseDuration ? livePauseDuration : 0))
         : 0;
 
+    const pauseReasonTotals = React.useMemo(() => {
+        const totals = {};
+        chastityHistory.forEach(p => {
+            (p.pauseEvents || []).forEach(ev => {
+                if (ev.duration && ev.reason) {
+                    totals[ev.reason] = (totals[ev.reason] || 0) + ev.duration;
+                }
+            });
+        });
+        return totals;
+    }, [chastityHistory]);
+
     return (
         <div className="app-wrapper">
             <div className="mb-4"><strong>Submissive’s Name:</strong> {savedSubmissivesName || '(Not Set)'}</div>
@@ -43,6 +55,7 @@ const FullReportPage = ({
                 totalChastityTime={totalChastityTime}
                 totalTimeCageOff={totalTimeCageOff}
                 overallTotalPauseTime={overallTotalPauseTime}
+                pauseReasonTotals={pauseReasonTotals}
             />
             <hr className="section-divider"/>
 

--- a/src/pages/TrackerPage.jsx
+++ b/src/pages/TrackerPage.jsx
@@ -4,6 +4,7 @@ import { FaPlay, FaPause, FaStop, FaLock, FaSpinner } from 'react-icons/fa';
 import { formatTime, formatElapsedTime, formatDaysOnly } from '../utils';
 import { useTrackerPage } from '../hooks/useTrackerPage'; // Import the new hook
 import EmergencyUnlockModal from '../components/tracker/EmergencyUnlockModal'; // Import the new modal component
+import { PAUSE_REASON_OPTIONS, REMOVAL_REASON_OPTIONS } from '../event_types.js';
 
 const TrackerPage = (props) => {
     // These props are passed through to the hook or used for other modals
@@ -18,7 +19,7 @@ const TrackerPage = (props) => {
         handleResumeSession,
         showPauseReasonModal,
         handleCancelPauseModal,
-        reasonForPauseInput, setReasonForPauseInput, handleConfirmPause,
+        pauseReason, setPauseReason, handleConfirmPause,
         livePauseDuration,
         pauseCooldownMessage,
         showRestoreSessionPrompt,
@@ -200,8 +201,13 @@ const TrackerPage = (props) => {
             <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4">
               <div className="bg-gray-800 p-6 md:p-8 rounded-xl shadow-lg text-center w-full max-w-md text-gray-50 border border-purple-700">
                 <h3 className="text-lg md:text-xl font-bold mb-4 text-purple-300">Reason for Cage Removal:</h3>
-                <textarea value={reasonForRemoval} onChange={(e) => setReasonForRemoval(e.target.value)} placeholder="Enter reason here (optional)" rows="4"
-                  className="w-full p-2 mb-6 rounded-lg border border-purple-600 bg-gray-900 text-gray-50 focus:outline-none focus:ring-2 focus:ring-purple-500"></textarea>
+                <select value={reasonForRemoval} onChange={(e) => setReasonForRemoval(e.target.value)}
+                  className="w-full p-2 mb-6 rounded-lg border border-purple-600 bg-gray-900 text-gray-50 focus:outline-none focus:ring-2 focus:ring-purple-500">
+                  <option value="">(Optional)</option>
+                  {REMOVAL_REASON_OPTIONS.map(r => (
+                      <option key={r} value={r}>{r}</option>
+                  ))}
+                </select>
                 <div className="flex flex-col sm:flex-row justify-around space-y-3 sm:space-y-0 sm:space-x-4">
                   <button type="button" onClick={handleConfirmRemoval} className="w-full sm:w-auto bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg transition">Confirm Removal</button>
                   <button type="button" onClick={handleCancelRemoval} className="w-full sm:w-auto bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg transition">Cancel</button>
@@ -214,8 +220,13 @@ const TrackerPage = (props) => {
             <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4">
               <div className="bg-gray-800 p-6 md:p-8 rounded-xl shadow-lg text-center w-full max-w-md text-gray-50 border border-yellow-700">
                 <h3 className="text-lg md:text-xl font-bold mb-4 text-yellow-300">Reason for Pausing Session:</h3>
-                <textarea value={reasonForPauseInput} onChange={(e) => setReasonForPauseInput(e.target.value)} placeholder="Enter reason here (optional)" rows="4"
-                  className="w-full p-2 mb-6 rounded-lg border border-yellow-600 bg-gray-900 text-gray-50 focus:outline-none focus:ring-2 focus:ring-yellow-500"></textarea>
+                <select value={pauseReason} onChange={(e) => setPauseReason(e.target.value)}
+                  className="w-full p-2 mb-6 rounded-lg border border-yellow-600 bg-gray-900 text-gray-50 focus:outline-none focus:ring-2 focus:ring-yellow-500">
+                  <option value="">(Optional)</option>
+                  {PAUSE_REASON_OPTIONS.map(r => (
+                      <option key={r} value={r}>{r}</option>
+                  ))}
+                </select>
                 <div className="flex flex-col sm:flex-row justify-around space-y-3 sm:space-y-0 sm:space-x-4">
                   <button type="button" onClick={handleConfirmPause} className="w-full sm:w-auto bg-yellow-600 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded-lg transition">Confirm Pause</button>
                   <button type="button" onClick={handleCancelPauseModal} className="w-full sm:w-auto bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg transition">Cancel</button>


### PR DESCRIPTION
## Summary
- add removal and pause reason options in event types
- store selected pause/removal reasons
- allow selecting pause/removal reasons on tracker page
- show total time paused by reason in full report

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863e8633c30832c8de7de14515d55b1