### PR TITLE
Add Beg for Release denial notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ ChastityOS is a modern chastity and FLR (Female-Led Relationship) tracking web a
 - Keyholder can set a required minimum chastity duration
 - Locked controls unless the user enters the correct 8-character password preview
 - Visual tracker shows progress toward required keyholder time
+- "Beg for Release" button replaces manual unlock when a keyholder lock is active
+- Denials show a message on the tracker and you must wait 4 hours before begging again
 
 ### 🎯 Goal Tracking
 - Set a personal chastity goal duration (optional)

--- a/src/components/keyholder/KeyholderDashboard.jsx
+++ b/src/components/keyholder/KeyholderDashboard.jsx
@@ -21,7 +21,10 @@ const KeyholderDashboard = ({
   handleAddPunishment,
   handleAddTask,
   handleApproveTask,
-  handleRejectTask
+  handleRejectTask,
+  releaseRequests = [],
+  handleGrantReleaseRequest,
+  handleDenyReleaseRequest
 }) => {
   const [khNameInput, setKhNameInput] = useState('');
   const [khPasswordInput, setKhPasswordInput] = useState('');
@@ -151,6 +154,21 @@ const KeyholderDashboard = ({
                 <TaskApprovalSection tasks={tasks} onApprove={handleApproveTask} onReject={handleRejectTask} />
                 {/* THE FIX: `onAddTask` now correctly calls `handleAddTask` from props */}
                 <KeyholderAddTaskForm onAddTask={handleAddTask} />
+
+                {releaseRequests.filter(r => r.status === 'pending').length > 0 && (
+                  <div className="mt-6 space-y-3">
+                    <h4 className="title-purple !text-purple-300">Release Requests</h4>
+                    {releaseRequests.filter(r => r.status === 'pending').map(req => (
+                      <div key={req.id} className="flex justify-between items-center p-2 border border-purple-700 rounded-md">
+                        <span className="text-sm">{req.submittedAt ? req.submittedAt.toLocaleString() : ''}</span>
+                        <div className="flex gap-2">
+                          <button onClick={() => handleGrantReleaseRequest(req.id)} className="button-green !text-green-300 px-2">Grant</button>
+                          <button onClick={() => handleDenyReleaseRequest(req.id)} className="button-red !text-red-300 px-2">Deny</button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             )}
           </>

--- a/src/hooks/useChastityState.jsx
+++ b/src/hooks/useChastityState.jsx
@@ -11,6 +11,7 @@ import { db } from '../firebase';
 import { collection } from 'firebase/firestore';
 import { useKeyholderHandlers } from './chastity/keyholderHandlers';
 import { sha256 } from '../utils/hash';
+import { useReleaseRequests } from './useReleaseRequests';
 
 export const useChastityState = () => {
   const authState = useAuth();
@@ -29,6 +30,8 @@ export const useChastityState = () => {
   // FIX: Destructure tasksState to isolate the `tasks` array from the other properties.
   const tasksState = useTasks(userId, isAuthReady);
   const { tasks, ...otherTaskState } = tasksState;
+
+  const releaseRequestState = useReleaseRequests(userId, isAuthReady);
   
   const sessionObjectForHooks = {
       isChastityOn: sessionState.isCageOn,
@@ -102,6 +105,23 @@ export const useChastityState = () => {
     requiredKeyholderDurationSeconds: sessionState.requiredKeyholderDurationSeconds,
   });
 
+  const handleGrantReleaseRequest = useCallback(async (requestId) => {
+    await releaseRequestState.updateReleaseRequest(requestId, {
+      status: 'granted',
+      grantedAt: serverTimestamp(),
+      handledBy: settings.keyholderName || 'Keyholder',
+    });
+    await sessionState.handleEndChastityNow('Release granted by keyholder');
+  }, [releaseRequestState, sessionState, settings.keyholderName]);
+
+  const handleDenyReleaseRequest = useCallback(async (requestId) => {
+    await releaseRequestState.updateReleaseRequest(requestId, {
+      status: 'denied',
+      deniedAt: serverTimestamp(),
+      handledBy: settings.keyholderName || 'Keyholder',
+    });
+  }, [releaseRequestState, settings.keyholderName]);
+
   const handleSubmitForReview = useCallback(async (taskId, note) => {
     if (!tasksState.updateTask) {
       console.error("updateTask function is not available.");
@@ -150,5 +170,8 @@ export const useChastityState = () => {
     handleSubmitForReview,
     keyholderName: settings.keyholderName,
     tasks: tasks, // Explicitly include the `tasks` array
+    ...releaseRequestState,
+    handleGrantReleaseRequest,
+    handleDenyReleaseRequest,
   };
 };

--- a/src/hooks/useReleaseRequests.js
+++ b/src/hooks/useReleaseRequests.js
@@ -1,0 +1,81 @@
+import { useState, useEffect, useCallback } from 'react';
+import { collection, query, onSnapshot, addDoc, updateDoc, deleteDoc, doc, serverTimestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export function useReleaseRequests(userId, isAuthReady) {
+  const [releaseRequests, setReleaseRequests] = useState([]);
+
+  const getCollectionRef = useCallback(() => {
+    if (!userId) return null;
+    return collection(db, 'users', userId, 'releaseRequests');
+  }, [userId]);
+
+  useEffect(() => {
+    if (!isAuthReady || !userId) {
+      setReleaseRequests([]);
+      return;
+    }
+
+    const colRef = getCollectionRef();
+    if (!colRef) return;
+
+    const q = query(colRef);
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const data = snapshot.docs.map(d => {
+        const item = d.data();
+        return {
+          id: d.id,
+          ...item,
+          submittedAt: item.submittedAt && typeof item.submittedAt.toDate === 'function'
+            ? item.submittedAt.toDate()
+            : null,
+          deniedAt: item.deniedAt && typeof item.deniedAt.toDate === 'function'
+            ? item.deniedAt.toDate()
+            : null,
+          grantedAt: item.grantedAt && typeof item.grantedAt.toDate === 'function'
+            ? item.grantedAt.toDate()
+            : null,
+        };
+      });
+      setReleaseRequests(data);
+    }, (error) => {
+      console.error('Error fetching release requests:', error);
+    });
+
+    return () => unsubscribe();
+  }, [isAuthReady, userId, getCollectionRef]);
+
+  const addReleaseRequest = useCallback(async () => {
+    const colRef = getCollectionRef();
+    if (!colRef) return;
+    try {
+      await addDoc(colRef, { status: 'pending', submittedAt: serverTimestamp() });
+    } catch (error) {
+      console.error('Error adding release request:', error);
+    }
+  }, [getCollectionRef]);
+
+  const updateReleaseRequest = useCallback(async (id, updates) => {
+    const colRef = getCollectionRef();
+    if (!colRef) return;
+    try {
+      const docRef = doc(colRef, id);
+      await updateDoc(docRef, updates);
+    } catch (error) {
+      console.error('Error updating release request:', error);
+    }
+  }, [getCollectionRef]);
+
+  const deleteReleaseRequest = useCallback(async (id) => {
+    const colRef = getCollectionRef();
+    if (!colRef) return;
+    try {
+      const docRef = doc(colRef, id);
+      await deleteDoc(docRef);
+    } catch (error) {
+      console.error('Error deleting release request:', error);
+    }
+  }, [getCollectionRef]);
+
+  return { releaseRequests, addReleaseRequest, updateReleaseRequest, deleteReleaseRequest };
+}

--- a/src/pages/TrackerPage.jsx
+++ b/src/pages/TrackerPage.jsx
@@ -34,7 +34,9 @@ const TrackerPage = (props) => {
         totalTimeCageOff,
         timeCageOff,
         pauseStartTime,
-        accumulatedPauseTimeThisSession
+        accumulatedPauseTimeThisSession,
+        releaseRequests = [],
+        addReleaseRequest
     } = props;
 
     // Call the new hook to get all the logic and state for this page
@@ -52,6 +54,18 @@ const TrackerPage = (props) => {
         handleAttemptEmergencyUnlock,
         setShowEmergencyUnlockModal,
     } = useTrackerPage(props); // Pass all props from parent to the hook
+
+    const hasPendingReleaseRequest = releaseRequests.some(r => r.status === 'pending');
+    const lastDeniedRequest = releaseRequests
+        .filter(r => r.status === 'denied' && r.deniedAt)
+        .sort((a, b) => b.deniedAt - a.deniedAt)[0];
+    const denialCooldownActive = lastDeniedRequest && (Date.now() - lastDeniedRequest.deniedAt.getTime() < 4 * 3600 * 1000);
+
+    const handleBegForRelease = async () => {
+        if (addReleaseRequest) {
+            await addReleaseRequest();
+        }
+    };
 
     if (!isAuthReady) {
         return (
@@ -118,9 +132,15 @@ const TrackerPage = (props) => {
                             Time Left in required chastity: {formatElapsedTime(requiredKeyholderDurationSeconds - effectiveTimeInChastityForGoal)}
                         </p>
                     )}
-                    {isCageOn && effectiveTimeInChastityForGoal >= requiredKeyholderDurationSeconds && (
+                {isCageOn && effectiveTimeInChastityForGoal >= requiredKeyholderDurationSeconds && (
                          <p className="text-lg font-bold text-pink-100">KH Duration Met!</p>
                     )}
+                </div>
+            )}
+
+            {denialCooldownActive && lastDeniedRequest && (
+                <div className="mb-4 p-2 rounded-md text-center bg-red-700/30 border border-red-600">
+                    <p className="text-sm text-red-300">Beg for Release denied by {lastDeniedRequest.handledBy || keyholderName} at {lastDeniedRequest.deniedAt.toLocaleString()}</p>
                 </div>
             )}
 
@@ -173,6 +193,11 @@ const TrackerPage = (props) => {
                   <button type="button" onClick={handleOpenUnlockModal} disabled={!isAuthReady || showRestoreSessionPrompt}
                       className="flex-grow font-bold py-3 px-5 md:py-4 md:px-6 rounded-lg shadow-md transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-opacity-75 text-white disabled:opacity-50 bg-red-700 hover:bg-red-800 focus:ring-red-500 flex items-center justify-center">
                      <FaLock className="mr-2"/> Emergency Unlock
+                  </button>
+              ) : requiredKeyholderDurationSeconds > 0 ? (
+                  <button type="button" onClick={handleBegForRelease} disabled={!isAuthReady || hasPendingReleaseRequest || denialCooldownActive || showRestoreSessionPrompt}
+                      className="flex-grow font-bold py-3 px-5 md:py-4 md:px-6 rounded-lg shadow-md transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-opacity-75 text-white disabled:opacity-50 bg-red-500 hover:bg-red-600 focus:ring-red-400">
+                      {hasPendingReleaseRequest ? 'Request Sent' : 'Beg for Release'}
                   </button>
               ) : (
                   <button type="button" onClick={handleToggleCage} disabled={!isAuthReady || isPaused || showRestoreSessionPrompt}


### PR DESCRIPTION
## Summary
- store which keyholder handled release requests and when
- add denialAt/grantedAt tracking in useReleaseRequests
- display denial notice on TrackerPage for four hours
- disable Beg for Release button during cooldown
- document the cooldown rule in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686328430c00832c9f75e76c9f8dca54