### PR TITLE
Add dropdown suggestions for keyholder tasks

### DIFF
--- a/src/components/keyholder/KeyholderAddTaskForm.jsx
+++ b/src/components/keyholder/KeyholderAddTaskForm.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { FaPlusCircle, FaExclamationTriangle } from 'react-icons/fa';
 
-const KeyholderAddTaskForm = ({ onAddTask }) => {
+const KeyholderAddTaskForm = ({ onAddTask, tasks = [] }) => {
   const [taskText, setTaskText] = useState('');
   const [deadline, setDeadline] = useState('');
   const [rewardType, setRewardType] = useState('none');
@@ -50,14 +50,51 @@ const KeyholderAddTaskForm = ({ onAddTask }) => {
     setPunishmentValue('');
   };
 
+  const recentTasks = tasks
+    .filter(t => t.assignedBy === 'keyholder' && t.text)
+    .sort((a, b) => {
+      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return bTime - aTime;
+    })
+    .slice(0, 3);
+
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
   return (
     <>
       <div className="tasks-container">
         <h4 className="text-lg font-semibold mb-3 pb-2 border-b border-blue-800">Assign a New Task</h4>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
+          <div className="relative">
             <label htmlFor="task-text" className="block text-xs font-medium mb-1">Task Description</label>
-            <input id="task-text" type="text" value={taskText} onChange={(e) => setTaskText(e.target.value)} placeholder="e.g., Polish my boots" className="w-full" required />
+            <input
+              id="task-text"
+              type="text"
+              value={taskText}
+              onChange={(e) => setTaskText(e.target.value)}
+              placeholder="e.g., Polish my boots"
+              className="w-full"
+              required
+              onFocus={() => setShowSuggestions(true)}
+              onBlur={() => setTimeout(() => setShowSuggestions(false), 100)}
+            />
+            {showSuggestions && recentTasks.length > 0 && (
+              <ul className="absolute z-10 w-full bg-gray-800 border border-gray-600 rounded-md mt-1">
+                {recentTasks.map(task => (
+                  <li
+                    key={task.id}
+                    className="px-3 py-2 hover:bg-gray-700 cursor-pointer"
+                    onMouseDown={() => {
+                      setTaskText(task.text);
+                      setShowSuggestions(false);
+                    }}
+                  >
+                    {task.text}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
 
           <div>

--- a/src/components/keyholder/KeyholderDashboard.jsx
+++ b/src/components/keyholder/KeyholderDashboard.jsx
@@ -150,7 +150,7 @@ const KeyholderDashboard = ({
                 {/* These components now correctly receive their respective handlers */}
                 <TaskApprovalSection tasks={tasks} onApprove={handleApproveTask} onReject={handleRejectTask} />
                 {/* THE FIX: `onAddTask` now correctly calls `handleAddTask` from props */}
-                <KeyholderAddTaskForm onAddTask={handleAddTask} />
+                <KeyholderAddTaskForm onAddTask={handleAddTask} tasks={tasks} />
               </div>
             )}
           </>


### PR DESCRIPTION
## Summary
- add dropdown suggestions of last three keyholder tasks using a custom menu
- pass tasks to `KeyholderAddTaskForm`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68633b8bbd30832c9413b9ad3ec26783