### PR TITLE
Ensure start time edits log correctly

### DIFF
--- a/src/hooks/useChastitySession.js
+++ b/src/hooks/useChastitySession.js
@@ -254,6 +254,8 @@ export const useChastitySession = (
             try {
                 await addDoc(eventsColRef, {
                     eventType: 'startTimeEdit',
+                    // Include an event type array so this appears in the sexual events log
+                    types: ['Session Edit'],
                     eventTimestamp: Timestamp.now(),
                     oldStartTime: cageOnTime.toISOString(),
                     newStartTime: newTime.toISOString(),

--- a/src/hooks/useChastityState.jsx
+++ b/src/hooks/useChastityState.jsx
@@ -19,7 +19,9 @@ export const useChastityState = () => {
   const settingsState = useSettings(userId, isAuthReady);
   const { settings, setSettings } = settingsState;
 
-  const getEventsCollectionRef = (uid) => collection(db, 'users', uid, 'events');
+  // Use the unified 'sexualEventsLog' collection for all session and event data
+  const getEventsCollectionRef = (uid) =>
+    collection(db, 'users', uid, 'sexualEventsLog');
   const eventLogState = useEventLog(userId, isAuthReady, getEventsCollectionRef);
   
   const sessionState = useChastitySession(

--- a/src/hooks/useDataManagement.js
+++ b/src/hooks/useDataManagement.js
@@ -74,7 +74,8 @@ export function useDataManagement({ userId, isAuthReady, userEmail, settings, se
         const oldTasksSnap = await getDocs(query(tasksCollectionRef));
         oldTasksSnap.forEach(doc => batch.delete(doc.ref));
 
-        const eventsCollectionRef = collection(db, 'users', userId, 'events');
+        // Use 'sexualEventsLog' for all event data
+        const eventsCollectionRef = collection(db, 'users', userId, 'sexualEventsLog');
         const oldEventsSnap = await getDocs(query(eventsCollectionRef));
         oldEventsSnap.forEach(doc => batch.delete(doc.ref));
         
@@ -143,8 +144,8 @@ export function useDataManagement({ userId, isAuthReady, userEmail, settings, se
         Sentry.captureException(error);
     }
     
-    // 3. (Optional but recommended) Delete all documents in the 'events' subcollection
-    const eventsCollectionRef = collection(db, 'users', userId, 'events');
+    // 3. Delete all documents in the 'sexualEventsLog' subcollection
+    const eventsCollectionRef = collection(db, 'users', userId, 'sexualEventsLog');
      try {
         const eventsSnapshot = await getDocs(query(eventsCollectionRef));
         eventsSnapshot.forEach(doc => {


### PR DESCRIPTION
## Summary
- log edited start times in the `sexualEventsLog` collection
- include a `types` field so the entry shows in the sexual event log
- wipe `sexualEventsLog` documents when performing a full reset

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863f62016a8832ca9d0180c37a0ed36