### PR TITLE
Fix start time persistence

### DIFF
--- a/src/hooks/useChastitySession.js
+++ b/src/hooks/useChastitySession.js
@@ -288,7 +288,9 @@ export const useChastitySession = (
                 setTimeout(() => setEditSessionMessage(''), 3000);
             }
         }
-        await saveDataToFirestore({ cageOnTime: newTime });
+        await saveDataToFirestore({ cageOnTime: newTime, isCageOn: true });
+        setEditSessionDateInput('');
+        setEditSessionTimeInput('');
         setEditSessionMessage("Start time updated successfully!");
         setTimeout(() => setEditSessionMessage(''), 3000);
     }, [isCageOn, cageOnTime, editSessionDateInput, editSessionTimeInput, getEventsCollectionRef, googleEmail, saveDataToFirestore, fetchEvents]);


### PR DESCRIPTION
## Summary
- ensure edited start times are saved with active session flag
- clear the edit inputs after updating

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686508848f80832c97be36f98d5c5564