### PR TITLE
Fix start time edit persistence

### DIFF
--- a/src/hooks/useChastitySession.js
+++ b/src/hooks/useChastitySession.js
@@ -171,7 +171,7 @@ export const useChastitySession = (
             setHasSessionEverBeenActive(true);
             saveDataToFirestore({
                 isCageOn: true,
-                cageOnTime: currentTime,
+                cageOnTime: Timestamp.fromDate(currentTime),
                 totalTimeCageOff: newTotalOffTime,
                 timeInChastity: 0,
                 cageOffStartTime: null,
@@ -288,7 +288,7 @@ export const useChastitySession = (
                 setTimeout(() => setEditSessionMessage(''), 3000);
             }
         }
-        await saveDataToFirestore({ cageOnTime: newTime });
+        await saveDataToFirestore({ cageOnTime: Timestamp.fromDate(newTime) });
         setEditSessionMessage("Start time updated successfully!");
         setTimeout(() => setEditSessionMessage(''), 3000);
     }, [isCageOn, cageOnTime, editSessionDateInput, editSessionTimeInput, getEventsCollectionRef, googleEmail, saveDataToFirestore, fetchEvents]);


### PR DESCRIPTION
## Summary
- ensure cage start time is saved as Firestore `Timestamp` when starting a session
- ensure edited start time is saved as a `Timestamp`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_686508848f80832c97be36f98d5c5564