### PR TITLE
Add activity heatmap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "firebase": "^11.8.1",
         "marked": "^9.1.6",
         "react": "^19.1.0",
+        "react-calendar-heatmap": "^1.8.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
         "react-helmet-async": "^2.0.5",
@@ -10676,6 +10677,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+      "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw==",
+      "license": "MIT"
+    },
     "node_modules/meow": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
@@ -11387,6 +11394,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -11777,6 +11793,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -11866,6 +11893,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar-heatmap": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/react-calendar-heatmap/-/react-calendar-heatmap-1.8.0.tgz",
+      "integrity": "sha512-Dsf2d2MKA31QzLN63fW6PTixJVzMCm2+KhprkGXaeZFvBAL2hK2guiYvr+zFpPkh1ZpGNYdrdNfn9FxhiBd1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "memoize-one": "^4.0.2",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/react-chartjs-2": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "firebase": "^11.8.1",
     "marked": "^9.1.6",
     "react": "^19.1.0",
+    "react-calendar-heatmap": "^1.8.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
     "react-helmet-async": "^2.0.5",

--- a/src/components/full_report/ChastityHeatmap.jsx
+++ b/src/components/full_report/ChastityHeatmap.jsx
@@ -56,7 +56,7 @@ const ChastityHeatmap = ({ chastityHistory, sexualEventsLog }) => {
           return 'color-github-1';
         }}
         titleForValue={value => {
-          if (!value) return '';
+          if (!value || !value.date) return '';
           return value.count
             ? `${value.date}: ${value.count} activity`
             : `${value.date}: no activity`;

--- a/src/components/full_report/ChastityHeatmap.jsx
+++ b/src/components/full_report/ChastityHeatmap.jsx
@@ -1,0 +1,69 @@
+import React, { useMemo } from 'react';
+import CalendarHeatmap from 'react-calendar-heatmap';
+import 'react-calendar-heatmap/dist/styles.css';
+import dayjs from 'dayjs';
+
+const ChastityHeatmap = ({ chastityHistory, sexualEventsLog }) => {
+  const endDate = dayjs().endOf('day').toDate();
+  const startDate = dayjs(endDate).subtract(180, 'day').toDate();
+
+  const values = useMemo(() => {
+    const map = {};
+
+    chastityHistory.forEach(session => {
+      const start = dayjs(session.startTime);
+      const end = dayjs(session.endTime || new Date());
+      for (
+        let d = start.startOf('day');
+        d.isBefore(end.endOf('day'));
+        d = d.add(1, 'day')
+      ) {
+        const key = d.format('YYYY-MM-DD');
+        map[key] = (map[key] || 0) + 1;
+      }
+    });
+
+    sexualEventsLog.forEach(ev => {
+      const ts = ev.eventTimestamp || ev.timestamp;
+      if (!ts) return;
+      const key = dayjs(ts).format('YYYY-MM-DD');
+      map[key] = (map[key] || 0) + 1;
+    });
+
+    const arr = [];
+    for (
+      let d = dayjs(startDate);
+      d.isBefore(dayjs(endDate).add(1, 'day'));
+      d = d.add(1, 'day')
+    ) {
+      const key = d.format('YYYY-MM-DD');
+      arr.push({ date: key, count: map[key] || 0 });
+    }
+    return arr;
+  }, [chastityHistory, sexualEventsLog, startDate, endDate]);
+
+  return (
+    <div className="my-4">
+      <CalendarHeatmap
+        startDate={startDate}
+        endDate={endDate}
+        values={values}
+        classForValue={value => {
+          if (!value || value.count === 0) return 'color-github-0';
+          if (value.count >= 4) return 'color-github-4';
+          if (value.count >= 3) return 'color-github-3';
+          if (value.count >= 2) return 'color-github-2';
+          return 'color-github-1';
+        }}
+        titleForValue={value =>
+          value && value.count
+            ? `${value.date}: ${value.count} activity`
+            : `${value.date}: no activity`
+        }
+        showWeekdayLabels={false}
+      />
+    </div>
+  );
+};
+
+export default ChastityHeatmap;

--- a/src/components/full_report/ChastityHeatmap.jsx
+++ b/src/components/full_report/ChastityHeatmap.jsx
@@ -55,11 +55,12 @@ const ChastityHeatmap = ({ chastityHistory, sexualEventsLog }) => {
           if (value.count >= 2) return 'color-github-2';
           return 'color-github-1';
         }}
-        titleForValue={value =>
-          value && value.count
+        titleForValue={value => {
+          if (!value) return '';
+          return value.count
             ? `${value.date}: ${value.count} activity`
-            : `${value.date}: no activity`
-        }
+            : `${value.date}: no activity`;
+        }}
         showWeekdayLabels={false}
       />
     </div>

--- a/src/pages/FullReportPage.jsx
+++ b/src/pages/FullReportPage.jsx
@@ -5,6 +5,7 @@ import TotalsSection from '../components/full_report/TotalsSection';
 import ChastityHistoryTable from '../components/full_report/ChastityHistoryTable';
 import EventLogTable from '../components/log_event/EventLogTable';
 import ArousalLevelChart from '../components/arousal/ArousalLevelChart';
+import ChastityHeatmap from '../components/full_report/ChastityHeatmap';
 
 const FullReportPage = ({
   savedSubmissivesName,
@@ -104,6 +105,10 @@ const FullReportPage = ({
         </label>
       </div>
       <ArousalLevelChart arousalLevels={arousalLevels} days={chartDays} />
+      <ChastityHeatmap
+        chastityHistory={chastityHistory}
+        sexualEventsLog={sexualEventsLog}
+      />
       <hr className="section-divider" />
 
       <h3 className="section-title">Chastity History</h3>


### PR DESCRIPTION
## Summary
- install `react-calendar-heatmap`
- create `ChastityHeatmap` component to visualize activity
- show heatmap on Full Report page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68650b147c2c832cb054537f9cfbcb88