### PR TITLE
Fix duplicate logging when button pressed quickly

### DIFF
--- a/src/components/log_event/LogEventForm.jsx
+++ b/src/components/log_event/LogEventForm.jsx
@@ -9,7 +9,7 @@ const LogEventForm = ({
     newEventNotes, setNewEventNotes,
     newEventDurationHours, setNewEventDurationHours, newEventDurationMinutes, setNewEventDurationMinutes,
     newEventSelfOrgasmAmount, setNewEventSelfOrgasmAmount, newEventPartnerOrgasmAmount, setNewEventPartnerOrgasmAmount,
-    handleLogNewEvent, eventLogMessage, isLoadingEvents, savedSubmissivesName, keyholderName,
+    handleLogNewEvent, eventLogMessage, isLoadingEvents, isSubmitting, savedSubmissivesName, keyholderName,
     eventDisplayMode, isNightly // Added isNightly prop for dynamic classes
 }) => {
     const showSelfOrgasmAmountInput = selectedEventTypes.includes("Orgasm (Self)");
@@ -99,7 +99,7 @@ const LogEventForm = ({
                 <label htmlFor="eventNotes" className={`block text-sm font-medium text-left ${isNightly ? 'text-nightly-accent' : 'text-prod-accent'}`}>Notes:</label>
                 <textarea id="eventNotes" value={newEventNotes} onChange={e => setNewEventNotes(e.target.value)} rows="3" className={`mt-1 block w-full px-3 py-2 rounded-md border bg-app-input text-app-text focus:ring-accent focus:border-accent`} placeholder="Optional details..."></textarea>
             </div>
-            <button type="submit" disabled={!isAuthReady || isLoadingEvents} className="w-full bg-accent hover:bg-accent-dark text-white font-semibold py-2 px-4 rounded-md shadow-sm transition duration-300 disabled:opacity-50">Log Event</button>
+            <button type="submit" disabled={!isAuthReady || isLoadingEvents || isSubmitting} className="w-full bg-accent hover:bg-accent-dark text-white font-semibold py-2 px-4 rounded-md shadow-sm transition duration-300 disabled:opacity-50">Log Event</button>
             {eventLogMessage && <p className={`text-sm mt-2 ${eventLogMessage.includes('success') ? 'text-green-400' : 'text-red-500'}`}>{eventLogMessage}</p>}
         </form>
     );

--- a/src/hooks/useEventLog.js
+++ b/src/hooks/useEventLog.js
@@ -6,6 +6,7 @@ import { db } from '../firebase';
 export const useEventLog = (userId, isAuthReady) => {
     const [sexualEventsLog, setSexualEventsLog] = useState([]);
     const [isLoadingEvents, setIsLoadingEvents] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
     const [eventLogMessage, setEventLogMessage] = useState('');
 
     // Form state
@@ -72,6 +73,7 @@ export const useEventLog = (userId, isAuthReady) => {
 
     const handleLogNewEvent = useCallback(async (e) => {
         e.preventDefault();
+        if (isSubmitting) return;
         if (!isAuthReady || !userId) {
             setEventLogMessage("Auth error.");
             setTimeout(() => setEventLogMessage(''), 3000);
@@ -118,6 +120,7 @@ export const useEventLog = (userId, isAuthReady) => {
         };
 
         try {
+            setIsSubmitting(true);
             await addDoc(eventsColRef, newEventData);
             setEventLogMessage("Event logged!");
             setNewEventDate(new Date().toISOString().slice(0, 10));
@@ -134,9 +137,11 @@ export const useEventLog = (userId, isAuthReady) => {
         } catch (error) {
             console.error("Error logging new event:", error);
             setEventLogMessage("Failed to log. See console.");
+        } finally {
+            setIsSubmitting(false);
         }
         setTimeout(() => setEventLogMessage(''), 3000);
-    }, [isAuthReady, userId, selectedEventTypes, otherEventTypeChecked, otherEventTypeDetail, newEventDate, newEventTime, newEventDurationHours, newEventDurationMinutes, newEventSelfOrgasmAmount, newEventPartnerOrgasmAmount, newEventNotes, getEventsCollectionRef, fetchEvents]);
+    }, [isAuthReady, userId, selectedEventTypes, otherEventTypeChecked, otherEventTypeDetail, newEventDate, newEventTime, newEventDurationHours, newEventDurationMinutes, newEventSelfOrgasmAmount, newEventPartnerOrgasmAmount, newEventNotes, getEventsCollectionRef, fetchEvents, isSubmitting]);
 
     return {
         sexualEventsLog,
@@ -155,6 +160,7 @@ export const useEventLog = (userId, isAuthReady) => {
         handleEventTypeChange,
         handleOtherEventTypeCheckChange,
         handleLogNewEvent,
+        isSubmitting,
         fetchEvents,
         getEventsCollectionRef, // For reset function
         setSexualEventsLog // Expose setter for reset


### PR DESCRIPTION
## Summary
- prevent rapid fire submission of log events by tracking submission state
- disable the Log Event button while submitting

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686483b24f38832cb565d42696a6a7eb