### PR TITLE
Implement public profile sharing

### DIFF
--- a/src/components/settings/PublicProfileSection.jsx
+++ b/src/components/settings/PublicProfileSection.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { makeProfileToken } from '../../utils/publicProfile';
+
+const sectionLabels = {
+  currentStatus: 'Current Status',
+  totals: 'Totals',
+  arousalChart: 'Arousal Chart',
+  chastityHistory: 'Chastity History',
+  sexualEvents: 'Sexual Events',
+};
+
+const PublicProfileSection = ({
+  userId,
+  savedSubmissivesName,
+  publicProfileEnabled,
+  publicStatsVisibility,
+  togglePublicProfileEnabled,
+  togglePublicStatVisibility,
+}) => {
+  const token = makeProfileToken(userId, savedSubmissivesName);
+  const shareLink = `${window.location.origin}?profile=${token}`;
+
+  return (
+    <div className="mb-8 p-4 bg-gray-800 border border-green-700 rounded-lg shadow-sm">
+      <h3 className="text-xl font-semibold text-green-300 mb-4">Public Profile</h3>
+      <label className="flex items-center space-x-2 mb-3 text-purple-200">
+        <input
+          type="checkbox"
+          checked={publicProfileEnabled}
+          onChange={togglePublicProfileEnabled}
+          className="form-checkbox h-5 w-5 text-green-500 bg-gray-700 border-gray-600 rounded"
+        />
+        <span>Enable Public Profile</span>
+      </label>
+      {publicProfileEnabled && (
+        <>
+          <p className="text-sm text-purple-200 mb-2">Share this link:</p>
+          <div className="bg-gray-900 p-2 rounded-md text-purple-100 text-sm mb-4 break-all">
+            {shareLink}
+          </div>
+          <p className="text-sm text-purple-200 mb-2">Visible Sections:</p>
+          <div className="space-y-2">
+            {Object.keys(sectionLabels).map((key) => (
+              <label key={key} className="flex items-center space-x-2 text-purple-200">
+                <input
+                  type="checkbox"
+                  checked={publicStatsVisibility?.[key] || false}
+                  onChange={() => togglePublicStatVisibility(key)}
+                  className="form-checkbox h-4 w-4 text-green-500 bg-gray-700 border-gray-600 rounded"
+                />
+                <span>{sectionLabels[key]}</span>
+              </label>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default PublicProfileSection;

--- a/src/hooks/useDataManagement.js
+++ b/src/hooks/useDataManagement.js
@@ -126,6 +126,14 @@ export function useDataManagement({ userId, isAuthReady, userEmail, settings, se
           isTrackingAllowed: true,
           eventDisplayMode: 'kinky',
           rulesText: '',
+          publicProfileEnabled: false,
+          publicStatsVisibility: {
+            currentStatus: true,
+            totals: true,
+            arousalChart: true,
+            chastityHistory: true,
+            sexualEvents: true,
+          },
         },
         // Reset all session-related fields as well
         requiredKeyholderDurationSeconds: 0,

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -9,6 +9,14 @@ const defaultSettings = {
   rulesText: '',
   isTrackingAllowed: true,
   eventDisplayMode: 'kinky',
+  publicProfileEnabled: false,
+  publicStatsVisibility: {
+    currentStatus: true,
+    totals: true,
+    arousalChart: true,
+    chastityHistory: true,
+    sexualEvents: true,
+  },
 };
 
 export function useSettings(userId, isAuthReady) {
@@ -89,6 +97,23 @@ export function useSettings(userId, isAuthReady) {
     updateSettings(prev => ({ ...prev, eventDisplayMode: mode }));
   }, [updateSettings]);
 
+  const togglePublicProfileEnabled = useCallback(() => {
+    updateSettings(prev => ({
+      ...prev,
+      publicProfileEnabled: !prev.publicProfileEnabled,
+    }));
+  }, [updateSettings]);
+
+  const togglePublicStatVisibility = useCallback((key) => {
+    updateSettings(prev => ({
+      ...prev,
+      publicStatsVisibility: {
+        ...prev.publicStatsVisibility,
+        [key]: !prev.publicStatsVisibility?.[key],
+      },
+    }));
+  }, [updateSettings]);
+
   return {
     settings,
     isLoading,
@@ -100,5 +125,9 @@ export function useSettings(userId, isAuthReady) {
     nameMessage,
     eventDisplayMode: settings.eventDisplayMode,
     handleSetEventDisplayMode,
+    publicProfileEnabled: settings.publicProfileEnabled,
+    publicStatsVisibility: settings.publicStatsVisibility,
+    togglePublicProfileEnabled,
+    togglePublicStatVisibility,
   };
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import PublicProfilePage from './pages/PublicProfilePage.jsx';
+import { extractUserIdFromToken } from './utils/publicProfile';
 import './index.css';
 import * as Sentry from "@sentry/react";
 import { HelmetProvider } from 'react-helmet-async';
@@ -42,12 +44,23 @@ if (sentryDsn) {
 }
 
 const SentryApp = Sentry.withProfiler(App);
+const SentryPublic = Sentry.withProfiler(PublicProfilePage);
+
+const params = new URLSearchParams(window.location.search);
+const profileToken = params.get('profile');
+const profileId = extractUserIdFromToken(profileToken);
+
+const RootComponent = profileId ? (
+  <SentryPublic profileId={profileId} />
+) : (
+  <SentryApp />
+);
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <Sentry.ErrorBoundary fallback={<p>An error has occurred</p>}>
       <HelmetProvider>
-        <SentryApp />
+        {RootComponent}
       </HelmetProvider>
     </Sentry.ErrorBoundary>
   </React.StrictMode>,

--- a/src/pages/PublicProfilePage.jsx
+++ b/src/pages/PublicProfilePage.jsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { loadPublicProfile } from '../utils/publicProfile';
+import { PAUSE_REASON_OPTIONS } from '../event_types.js';
+import CurrentStatusSection from '../components/full_report/CurrentStatusSection';
+import TotalsSection from '../components/full_report/TotalsSection';
+import ChastityHistoryTable from '../components/full_report/ChastityHistoryTable';
+import EventLogTable from '../components/log_event/EventLogTable';
+import ArousalLevelChart from '../components/arousal/ArousalLevelChart';
+
+const PublicProfilePage = ({ profileId }) => {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      const d = await loadPublicProfile(profileId);
+      setData(d);
+      setLoading(false);
+    })();
+  }, [profileId]);
+
+  const visibility = data?.settings?.publicStatsVisibility || {};
+
+  const effectiveCurrentSessionTime = useMemo(() => {
+    if (!data) return 0;
+    const s = data.sessionData;
+    return s.isCageOn
+      ? Math.max(
+          0,
+          s.timeInChastity -
+            s.accumulatedPauseTimeThisSession -
+            (s.isPaused && s.livePauseDuration ? s.livePauseDuration : 0)
+        )
+      : 0;
+  }, [data]);
+
+  const pauseReasonTotals = useMemo(() => {
+    if (!data) return {};
+    const totals = {};
+    (data.sessionData.chastityHistory || []).forEach((p) => {
+      (p.pauseEvents || []).forEach((ev) => {
+        if (!ev.duration || !ev.reason) return;
+        const category = PAUSE_REASON_OPTIONS.includes(ev.reason)
+          ? ev.reason
+          : 'Other';
+        totals[category] = (totals[category] || 0) + ev.duration;
+      });
+    });
+    return totals;
+  }, [data]);
+
+  if (loading) return <div className="loading-fullscreen">Loading...</div>;
+  if (!data || !data.settings?.publicProfileEnabled) {
+    return (
+      <div className="text-center p-6 text-purple-200">This public profile is not available.</div>
+    );
+  }
+
+  const { settings, sessionData, events, arousalLevels } = data;
+
+  return (
+    <div className="app-wrapper">
+      <h2 className="subpage-title no-border">{settings.submissivesName || 'User'}'s Public Stats</h2>
+      {visibility.currentStatus && (
+        <>
+          <CurrentStatusSection
+            isCageOn={sessionData.isCageOn}
+            isPaused={sessionData.isPaused}
+            cageOnTime={sessionData.cageOnTime}
+            effectiveCurrentSessionTime={effectiveCurrentSessionTime}
+            accumulatedPauseTimeThisSession={sessionData.accumulatedPauseTimeThisSession}
+            livePauseDuration={sessionData.livePauseDuration}
+            timeCageOff={sessionData.timeCageOff}
+          />
+          <hr className="section-divider" />
+        </>
+      )}
+      {visibility.totals && (
+        <>
+          <TotalsSection
+            totalChastityTime={sessionData.totalChastityTime}
+            totalTimeCageOff={sessionData.totalTimeCageOff}
+            overallTotalPauseTime={sessionData.overallTotalPauseTime}
+            pauseReasonTotals={pauseReasonTotals}
+          />
+          <hr className="section-divider" />
+        </>
+      )}
+      {visibility.arousalChart && (
+        <>
+          <h3 className="section-title">Arousal Level History</h3>
+          <ArousalLevelChart arousalLevels={arousalLevels} days={30} />
+          <hr className="section-divider" />
+        </>
+      )}
+      {visibility.chastityHistory && (
+        <>
+          <h3 className="section-title">Chastity History</h3>
+          <ChastityHistoryTable chastityHistory={sessionData.chastityHistory || []} />
+          <hr className="section-divider" />
+        </>
+      )}
+      {visibility.sexualEvents && (
+        <>
+          <h3 className="section-title">Sexual Events Log</h3>
+          <EventLogTable
+            isLoadingEvents={false}
+            sexualEventsLog={events}
+            savedSubmissivesName={settings.submissivesName}
+            eventDisplayMode={settings.eventDisplayMode}
+          />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default PublicProfilePage;

--- a/src/pages/SettingsMainPage.jsx
+++ b/src/pages/SettingsMainPage.jsx
@@ -3,6 +3,7 @@ import AccountSection from '../components/settings/AccountSection';
 import DisplaySettingsSection from '../components/settings/DisplaySettingsSection';
 import SessionEditSection from '../components/settings/SessionEditSection';
 import PersonalGoalSection from '../components/settings/PersonalGoalSection';
+import PublicProfileSection from '../components/settings/PublicProfileSection';
 
 const SettingsMainPage = (props) => {
     const { setCurrentPage } = props;
@@ -18,6 +19,7 @@ const SettingsMainPage = (props) => {
             {/* All sections receive the necessary props from the main `chastityOS` object */}
             <AccountSection {...props} />
             <DisplaySettingsSection {...props} />
+            <PublicProfileSection {...props} />
             <PersonalGoalSection {...props} />
             <SessionEditSection {...props} />
             

--- a/src/utils/publicProfile.js
+++ b/src/utils/publicProfile.js
@@ -1,0 +1,72 @@
+import { doc, getDoc, collection, getDocs, query, orderBy } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export function makeProfileToken(userId, submissiveName = '') {
+  const slug = submissiveName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `${slug}-${userId}`;
+}
+
+export function extractUserIdFromToken(token = '') {
+  if (!token) return null;
+  const lastDash = token.lastIndexOf('-');
+  return lastDash === -1 ? token : token.slice(lastDash + 1);
+}
+
+export async function loadPublicProfile(userId) {
+  if (!userId) return null;
+  try {
+    const userRef = doc(db, 'users', userId);
+    const userSnap = await getDoc(userRef);
+    if (!userSnap.exists()) return null;
+    const data = userSnap.data();
+
+    const settings = data.settings || {};
+
+    const sessionData = {
+      isCageOn: data.isCageOn || false,
+      cageOnTime: data.cageOnTime?.toDate ? data.cageOnTime.toDate() : null,
+      timeInChastity: data.timeInChastity || 0,
+      timeCageOff: data.timeCageOff || 0,
+      totalChastityTime: data.totalChastityTime || 0,
+      totalTimeCageOff: data.totalTimeCageOff || 0,
+      overallTotalPauseTime: data.overallTotalPauseTime || 0,
+      accumulatedPauseTimeThisSession: data.accumulatedPauseTimeThisSession || 0,
+      livePauseDuration: data.livePauseDuration || 0,
+      isPaused: data.isPaused || false,
+      chastityHistory: (data.chastityHistory || []).map((p) => ({
+        ...p,
+        startTime: p.startTime?.toDate ? p.startTime.toDate() : null,
+        endTime: p.endTime?.toDate ? p.endTime.toDate() : null,
+        pauseEvents: (p.pauseEvents || []).map((ev) => ({
+          ...ev,
+          startTime: ev.startTime?.toDate ? ev.startTime.toDate() : null,
+          endTime: ev.endTime?.toDate ? ev.endTime.toDate() : null,
+        })),
+      })),
+    };
+
+    const eventsSnap = await getDocs(query(collection(db, 'users', userId, 'sexualEventsLog'), orderBy('eventTimestamp', 'desc')));
+    const events = eventsSnap.docs.map((d) => ({
+      id: d.id,
+      ...d.data(),
+      eventTimestamp: d.data().eventTimestamp?.toDate(),
+      timestamp: d.data().timestamp?.toDate(),
+    }));
+
+    const arousalSnap = await getDocs(query(collection(db, 'users', userId, 'arousalLevels'), orderBy('timestamp', 'desc')));
+    const arousalLevels = arousalSnap.docs.map((d) => ({
+      id: d.id,
+      ...d.data(),
+      timestamp: d.data().timestamp?.toDate(),
+    }));
+
+    return { settings, sessionData, events, arousalLevels };
+  } catch (err) {
+    console.error('Failed to load public profile', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- allow configuring public profile visibility in settings
- generate shareable profile link
- load public profile with limited sections
- show public profile page when `?profile=<id>` is in URL
- use submissive name and user ID together in the link

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68652a4cd3cc832c8f266f3b624b6277