### PR TITLE
Add keyholder share code

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ ChastityOS is a modern chastity and FLR (Female-Led Relationship) tracking web a
 ### ☁️ Import/Export JSON
 - Allow users to backup and migrate data manually between devices or browsers via JSON file import/export.
 
+### 🔗 Keyholder Linking
+- Generate a short code from Settings that your keyholder can enter to link accounts.
+
 ### 🔐 Authentication Options
 - Default anonymous sign-in (no setup required)
 - Optional upgrade to sign in with Google account

--- a/src/components/settings/KeyholderLinkSection.jsx
+++ b/src/components/settings/KeyholderLinkSection.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { generateKeyholderToken, getUserIdFromKeyholderToken } from '../../utils/keyholderLink';
+
+const KeyholderLinkSection = ({ userId, setSettings, linkedKeyholderId }) => {
+  const [shareToken, setShareToken] = useState('');
+  const [inputToken, setInputToken] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleGenerate = async () => {
+    const token = await generateKeyholderToken(userId);
+    setShareToken(token || '');
+  };
+
+  const handleLink = async () => {
+    const uid = await getUserIdFromKeyholderToken(inputToken.trim());
+    if (uid) {
+      setSettings(prev => ({ ...prev, linkedKeyholderId: uid }));
+      setMessage('Linked successfully!');
+    } else {
+      setMessage('Invalid code');
+    }
+    setTimeout(() => setMessage(''), 3000);
+  };
+
+  return (
+    <div className="mb-8 p-4 bg-gray-800 border border-indigo-700 rounded-lg shadow-sm">
+      <h3 className="text-xl font-semibold text-indigo-300 mb-4">Keyholder Link</h3>
+      <button onClick={handleGenerate} className="mb-3 w-full sm:w-auto bg-indigo-600 hover:bg-indigo-700 text-white text-sm py-1.5 px-3 rounded-md">
+        Generate Share Code
+      </button>
+      {shareToken && (
+        <div className="text-left mb-4">
+          <p className="text-sm text-purple-200 mb-1">Share this code with your keyholder:</p>
+          <div className="bg-gray-900 p-2 rounded-md text-purple-100 text-sm break-all">
+            {shareToken}
+          </div>
+        </div>
+      )}
+      <div className="flex flex-col sm:flex-row items-center sm:space-x-3 mt-2">
+        <input
+          type="text"
+          value={inputToken}
+          onChange={(e) => setInputToken(e.target.value)}
+          placeholder="Enter Keyholder Code"
+          className="w-full sm:w-auto px-3 py-1.5 rounded-md border border-indigo-600 bg-gray-900 text-gray-50 text-sm focus:ring-indigo-500 focus:border-indigo-500"
+        />
+        <button
+          type="button"
+          onClick={handleLink}
+          className="w-full sm:w-auto bg-indigo-600 hover:bg-indigo-700 text-white text-sm py-1.5 px-3 rounded-md mt-2 sm:mt-0"
+        >
+          Link Account
+        </button>
+      </div>
+      {linkedKeyholderId && (
+        <p className="text-sm text-green-400 mt-3 text-left">Linked to user: {linkedKeyholderId}</p>
+      )}
+      {message && (
+        <p className="text-sm text-yellow-400 mt-2 text-left">{message}</p>
+      )}
+    </div>
+  );
+};
+
+export default KeyholderLinkSection;

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -17,6 +17,7 @@ const defaultSettings = {
     chastityHistory: true,
     sexualEvents: true,
   },
+  linkedKeyholderId: '',
 };
 
 export function useSettings(userId, isAuthReady) {
@@ -129,5 +130,6 @@ export function useSettings(userId, isAuthReady) {
     publicStatsVisibility: settings.publicStatsVisibility,
     togglePublicProfileEnabled,
     togglePublicStatVisibility,
+    linkedKeyholderId: settings.linkedKeyholderId,
   };
 }

--- a/src/pages/SettingsMainPage.jsx
+++ b/src/pages/SettingsMainPage.jsx
@@ -4,6 +4,7 @@ import DisplaySettingsSection from '../components/settings/DisplaySettingsSectio
 import SessionEditSection from '../components/settings/SessionEditSection';
 import PersonalGoalSection from '../components/settings/PersonalGoalSection';
 import PublicProfileSection from '../components/settings/PublicProfileSection';
+import KeyholderLinkSection from '../components/settings/KeyholderLinkSection';
 
 const SettingsMainPage = (props) => {
     const { setCurrentPage } = props;
@@ -20,6 +21,7 @@ const SettingsMainPage = (props) => {
             <AccountSection {...props} />
             <DisplaySettingsSection {...props} />
             <PublicProfileSection {...props} />
+            <KeyholderLinkSection {...props} />
             <PersonalGoalSection {...props} />
             <SessionEditSection {...props} />
             

--- a/src/utils/keyholderLink.js
+++ b/src/utils/keyholderLink.js
@@ -1,0 +1,15 @@
+import { doc, setDoc, getDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export async function generateKeyholderToken(userId) {
+  if (!userId) return null;
+  const token = Math.random().toString(36).substring(2, 8).toUpperCase();
+  await setDoc(doc(db, 'keyholderLinks', token), { userId });
+  return token;
+}
+
+export async function getUserIdFromKeyholderToken(token) {
+  if (!token) return null;
+  const snap = await getDoc(doc(db, 'keyholderLinks', token));
+  return snap.exists() ? snap.data().userId : null;
+}


### PR DESCRIPTION
## Summary
- add KeyholderLinkSection in Settings
- support linking by short token via Firestore
- expose linked keyholder ID in settings state
- document keyholder linking feature

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68654c043d5c832c91d294cbbbfe7f09