### PR TITLE
Fix tasks not shown on Tasks page

### DIFF
--- a/src/components/keyholder/KeyholderAddTaskForm.jsx
+++ b/src/components/keyholder/KeyholderAddTaskForm.jsx
@@ -59,7 +59,7 @@ const KeyholderAddTaskForm = ({ onAddTask, tasks = [] }) => {
   };
 
   const recentTasks = tasks
-    .filter(t => t.assignedBy === 'keyholder' && t.text)
+    .filter(t => t.text)
     .sort((a, b) => {
       const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
       const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;

--- a/src/pages/TasksPage.jsx
+++ b/src/pages/TasksPage.jsx
@@ -78,7 +78,7 @@ const TasksPage = ({ tasks = [], handleSubmitForReview, savedSubmissivesName }) 
     setNotes(prev => ({ ...prev, [taskId]: text }));
   };
 
-  const pendingTasks = tasks.filter(task => task.assignedBy === 'keyholder' && task.status === 'pending');
+  const pendingTasks = tasks.filter(task => task.status === 'pending');
   const submittedTasks = tasks.filter(task => task.status === 'pending_approval');
   const archivedTasks = tasks.filter(task => task.status === 'approved' || task.status === 'rejected');
 


### PR DESCRIPTION
## Summary
- simplify recent tasks suggestion logic
- show all tasks still pending regardless of their `assignedBy` field

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865482e5d18832cbb2e622866ee1348