### PR TITLE
Add keyholder share code

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ChastityOS is a modern chastity and FLR (Female-Led Relationship) tracking web a
 - Allow users to backup and migrate data manually between devices or browsers via JSON file import/export.
 
 ### 🔗 Keyholder Linking
-- Generate a short code from Settings that your keyholder can enter to link accounts.
+- Generate a short code or shareable link in Settings so your keyholder can easily link accounts.
 
 ### 🔐 Authentication Options
 - Default anonymous sign-in (no setup required)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ ChastityOS is a modern chastity and FLR (Female-Led Relationship) tracking web a
 ### ☁️ Import/Export JSON
 - Allow users to backup and migrate data manually between devices or browsers via JSON file import/export.
 
+### 🔗 Keyholder Linking
+- Generate a short code from Settings that your keyholder can enter to link accounts.
+
 ### 🔐 Authentication Options
 - Default anonymous sign-in (no setup required)
 - Optional upgrade to sign in with Google account

--- a/src/components/settings/KeyholderLinkSection.jsx
+++ b/src/components/settings/KeyholderLinkSection.jsx
@@ -1,10 +1,18 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { generateKeyholderToken, getUserIdFromKeyholderToken } from '../../utils/keyholderLink';
 
 const KeyholderLinkSection = ({ userId, setSettings, linkedKeyholderId }) => {
   const [shareToken, setShareToken] = useState('');
   const [inputToken, setInputToken] = useState('');
   const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const tokenFromUrl = params.get('kh');
+    if (tokenFromUrl) {
+      setInputToken(tokenFromUrl);
+    }
+  }, []);
 
   const handleGenerate = async () => {
     const token = await generateKeyholderToken(userId);
@@ -29,10 +37,18 @@ const KeyholderLinkSection = ({ userId, setSettings, linkedKeyholderId }) => {
         Generate Share Code
       </button>
       {shareToken && (
-        <div className="text-left mb-4">
-          <p className="text-sm text-purple-200 mb-1">Share this code with your keyholder:</p>
-          <div className="bg-gray-900 p-2 rounded-md text-purple-100 text-sm break-all">
-            {shareToken}
+        <div className="text-left mb-4 space-y-2">
+          <div>
+            <p className="text-sm text-purple-200 mb-1">Share this code with your keyholder:</p>
+            <div className="bg-gray-900 p-2 rounded-md text-purple-100 text-sm break-all">
+              {shareToken}
+            </div>
+          </div>
+          <div>
+            <p className="text-sm text-purple-200 mb-1">Or share this link:</p>
+            <div className="bg-gray-900 p-2 rounded-md text-purple-100 text-sm break-all">
+              {`${window.location.origin}?kh=${shareToken}`}
+            </div>
           </div>
         </div>
       )}

--- a/src/components/settings/KeyholderLinkSection.jsx
+++ b/src/components/settings/KeyholderLinkSection.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { generateKeyholderToken, getUserIdFromKeyholderToken } from '../../utils/keyholderLink';
+
+const KeyholderLinkSection = ({ userId, setSettings, linkedKeyholderId }) => {
+  const [shareToken, setShareToken] = useState('');
+  const [inputToken, setInputToken] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleGenerate = async () => {
+    const token = await generateKeyholderToken(userId);
+    setShareToken(token || '');
+  };
+
+  const handleLink = async () => {
+    const uid = await getUserIdFromKeyholderToken(inputToken.trim());
+    if (uid) {
+      setSettings(prev => ({ ...prev, linkedKeyholderId: uid }));
+      setMessage('Linked successfully!');
+    } else {
+      setMessage('Invalid code');
+    }
+    setTimeout(() => setMessage(''), 3000);
+  };
+
+  return (
+    <div className="mb-8 p-4 bg-gray-800 border border-indigo-700 rounded-lg shadow-sm">
+      <h3 className="text-xl font-semibold text-indigo-300 mb-4">Keyholder Link</h3>
+      <button onClick={handleGenerate} className="mb-3 w-full sm:w-auto bg-indigo-600 hover:bg-indigo-700 text-white text-sm py-1.5 px-3 rounded-md">
+        Generate Share Code
+      </button>
+      {shareToken && (
+        <div className="text-left mb-4">
+          <p className="text-sm text-purple-200 mb-1">Share this code with your keyholder:</p>
+          <div className="bg-gray-900 p-2 rounded-md text-purple-100 text-sm break-all">
+            {shareToken}
+          </div>
+        </div>
+      )}
+      <div className="flex flex-col sm:flex-row items-center sm:space-x-3 mt-2">
+        <input
+          type="text"
+          value={inputToken}
+          onChange={(e) => setInputToken(e.target.value)}
+          placeholder="Enter Keyholder Code"
+          className="w-full sm:w-auto px-3 py-1.5 rounded-md border border-indigo-600 bg-gray-900 text-gray-50 text-sm focus:ring-indigo-500 focus:border-indigo-500"
+        />
+        <button
+          type="button"
+          onClick={handleLink}
+          className="w-full sm:w-auto bg-indigo-600 hover:bg-indigo-700 text-white text-sm py-1.5 px-3 rounded-md mt-2 sm:mt-0"
+        >
+          Link Account
+        </button>
+      </div>
+      {linkedKeyholderId && (
+        <p className="text-sm text-green-400 mt-3 text-left">Linked to user: {linkedKeyholderId}</p>
+      )}
+      {message && (
+        <p className="text-sm text-yellow-400 mt-2 text-left">{message}</p>
+      )}
+    </div>
+  );
+};
+
+export default KeyholderLinkSection;

--- a/src/contexts/ActiveUserContext.jsx
+++ b/src/contexts/ActiveUserContext.jsx
@@ -1,0 +1,30 @@
+import React, { createContext, useState, useEffect } from 'react';
+import { auth } from '../firebase';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+const ActiveUserContext = createContext();
+
+export const ActiveUserProvider = ({ children }) => {
+  const [activeUserId, setActiveUserId] = useState(auth.currentUser?.uid || null);
+
+  useEffect(() => {
+    const init = async () => {
+      if (!auth.currentUser) return;
+      const docSnap = await getDoc(doc(db, 'users', auth.currentUser.uid));
+      if (docSnap.exists()) {
+        const data = docSnap.data();
+        if (data.linkedKeyholderId) {
+          setActiveUserId(data.linkedKeyholderId);
+        }
+      }
+    };
+    init();
+  }, []);
+
+  return (
+    <ActiveUserContext.Provider value={{ activeUserId, setActiveUserId }}>
+      {children}
+    </ActiveUserContext.Provider>
+  );
+};

--- a/src/hooks/useActiveUser.js
+++ b/src/hooks/useActiveUser.js
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import ActiveUserContext from '../contexts/ActiveUserContext';
+
+export const useActiveUser = () => useContext(ActiveUserContext);

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -70,7 +70,8 @@ export const useAuth = () => {
 
     return {
         user,
-        userId,
+        primaryUserId: userId,
+        activeUserId: user ? user.uid : null,
         googleEmail,
         isAuthReady,
         isLoading,

--- a/src/hooks/useChastityState.jsx
+++ b/src/hooks/useChastityState.jsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { serverTimestamp } from 'firebase/firestore';
 import { useAuth } from './useAuth';
+import { useActiveUser } from './useActiveUser';
 import { useSettings } from './useSettings';
 import { useEventLog } from './useEventLog';
 import { useArousalLevels } from './useArousalLevels';
@@ -17,7 +18,10 @@ import { useReleaseRequests } from './useReleaseRequests';
 
 export const useChastityState = () => {
   const authState = useAuth();
-  const { userId, isAuthReady, googleEmail } = authState;
+  const { isAuthReady, googleEmail } = authState;
+
+  const { activeUserId } = useActiveUser();
+  const userId = activeUserId;
 
   const settingsState = useSettings(userId, isAuthReady);
   const { settings, setSettings } = settingsState;

--- a/src/hooks/useDataManagement.js
+++ b/src/hooks/useDataManagement.js
@@ -1,10 +1,12 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useContext } from 'react';
 import { db } from '../firebase';
 // Fix: Removed unused 'getDoc' and 'setDoc' imports.
 import { doc, writeBatch, collection, getDocs, query } from 'firebase/firestore';
 import * as Sentry from '@sentry/react';
+import { UserContext } from '../context/UserContext';
 
-export function useDataManagement({ userId, isAuthReady, userEmail, settings, session, events, tasks }) {
+export function useDataManagement({ isAuthReady, userEmail, settings, session, events, tasks }) {
+  const { activeUserId: userId } = useContext(UserContext);
   const [exportMessage, setExportMessage] = useState('');
   const [importMessage, setImportMessage] = useState('');
 

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -17,6 +17,7 @@ const defaultSettings = {
     chastityHistory: true,
     sexualEvents: true,
   },
+  linkedKeyholderId: '',
 };
 
 export function useSettings(userId, isAuthReady) {
@@ -129,5 +130,6 @@ export function useSettings(userId, isAuthReady) {
     publicStatsVisibility: settings.publicStatsVisibility,
     togglePublicProfileEnabled,
     togglePublicStatVisibility,
+    linkedKeyholderId: settings.linkedKeyholderId,
   };
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,6 +6,7 @@ import { extractUserIdFromToken } from './utils/publicProfile';
 import './index.css';
 import * as Sentry from "@sentry/react";
 import { HelmetProvider } from 'react-helmet-async';
+import { ActiveUserProvider } from './contexts/ActiveUserContext.jsx';
 
 // Read all Sentry config from environment variables
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
@@ -60,7 +61,9 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <Sentry.ErrorBoundary fallback={<p>An error has occurred</p>}>
       <HelmetProvider>
-        {RootComponent}
+        <ActiveUserProvider>
+          {RootComponent}
+        </ActiveUserProvider>
       </HelmetProvider>
     </Sentry.ErrorBoundary>
   </React.StrictMode>,

--- a/src/pages/SettingsMainPage.jsx
+++ b/src/pages/SettingsMainPage.jsx
@@ -4,6 +4,7 @@ import DisplaySettingsSection from '../components/settings/DisplaySettingsSectio
 import SessionEditSection from '../components/settings/SessionEditSection';
 import PersonalGoalSection from '../components/settings/PersonalGoalSection';
 import PublicProfileSection from '../components/settings/PublicProfileSection';
+import KeyholderLinkSection from '../components/settings/KeyholderLinkSection';
 
 const SettingsMainPage = (props) => {
     const { setCurrentPage } = props;
@@ -20,6 +21,7 @@ const SettingsMainPage = (props) => {
             <AccountSection {...props} />
             <DisplaySettingsSection {...props} />
             <PublicProfileSection {...props} />
+            <KeyholderLinkSection {...props} />
             <PersonalGoalSection {...props} />
             <SessionEditSection {...props} />
             

--- a/src/utils/keyholderLink.js
+++ b/src/utils/keyholderLink.js
@@ -1,15 +1,75 @@
-import { doc, setDoc, getDoc } from 'firebase/firestore';
+import { doc, setDoc, getDoc, deleteDoc, serverTimestamp } from 'firebase/firestore';
 import { db } from '../firebase';
 
-export async function generateKeyholderToken(userId) {
-  if (!userId) return null;
-  const token = Math.random().toString(36).substring(2, 8).toUpperCase();
-  await setDoc(doc(db, 'keyholderLinks', token), { userId });
+/**
+ * Generates a secure keyholder token linked to a userId.
+ * Stores the token with userId and createdAt timestamp in 'keyholderLinks'.
+ * @param {string} userId - The user ID to link the token to.
+ * @param {string} ownerUid - The owner UID who owns this token.
+ * @returns {Promise<string|null>} The generated token or null if userId is not provided.
+ */
+export async function generateKeyholderToken(userId, ownerUid) {
+  if (!userId || !ownerUid) return null;
+  const token = generateSecureToken(6);
+  const now = serverTimestamp();
+  await setDoc(doc(db, 'keyholderLinks', token), { userId, createdAt: now });
   return token;
 }
 
+/**
+ * Retrieves the userId associated with a given keyholder token.
+ * @param {string} token - The keyholder token.
+ * @returns {Promise<string|null>} The userId if token exists, otherwise null.
+ */
 export async function getUserIdFromKeyholderToken(token) {
   if (!token) return null;
   const snap = await getDoc(doc(db, 'keyholderLinks', token));
   return snap.exists() ? snap.data().userId : null;
+}
+
+/**
+ * Creates an account link record explicitly linking a linkedUid to an ownerUid.
+ * @param {string} linkedUid - The UID being linked.
+ * @param {string} ownerUid - The owner UID.
+ * @returns {Promise<void>}
+ */
+export async function createAccountLinkForLinkedUid(linkedUid, ownerUid) {
+  if (!linkedUid || !ownerUid) throw new Error('linkedUid and ownerUid are required');
+  const now = serverTimestamp();
+  const docId = `${ownerUid}_${linkedUid}`;
+  await setDoc(doc(db, 'accountLinks', docId), { linkedUid, ownerUid, createdAt: now });
+}
+
+/**
+ * Deletes a keyholder token.
+ * @param {string} token - The token to delete.
+ * @returns {Promise<void>}
+ */
+export async function deleteKeyholderToken(token) {
+  if (!token) return;
+  await deleteDoc(doc(db, 'keyholderLinks', token));
+}
+
+/**
+ * Deletes an account link record.
+ * @param {string} ownerUid - The owner UID.
+ * @param {string} linkedUid - The linked UID.
+ * @returns {Promise<void>}
+ */
+export async function deleteAccountLink(ownerUid, linkedUid) {
+  if (!ownerUid || !linkedUid) return;
+  const docId = `${ownerUid}_${linkedUid}`;
+  await deleteDoc(doc(db, 'accountLinks', docId));
+}
+
+/**
+ * Generates a secure random alphanumeric token of given length.
+ * @param {number} length - Length of the token.
+ * @returns {string} The generated token.
+ */
+function generateSecureToken(length) {
+  const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  const array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  return Array.from(array, (x) => charset[x % charset.length]).join('');
 }

--- a/src/utils/keyholderLink.js
+++ b/src/utils/keyholderLink.js
@@ -1,0 +1,15 @@
+import { doc, setDoc, getDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export async function generateKeyholderToken(userId) {
+  if (!userId) return null;
+  const token = Math.random().toString(36).substring(2, 8).toUpperCase();
+  await setDoc(doc(db, 'keyholderLinks', token), { userId });
+  return token;
+}
+
+export async function getUserIdFromKeyholderToken(token) {
+  if (!token) return null;
+  const snap = await getDoc(doc(db, 'keyholderLinks', token));
+  return snap.exists() ? snap.data().userId : null;
+}


### PR DESCRIPTION
## Summary
- add KeyholderLinkSection in Settings
- support linking by short token via Firestore
- expose linked keyholder ID in settings state
- document keyholder linking feature

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68654c043d5c832c91d294cbbbfe7f09