### PR TITLE
Enable offline Firestore caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ ChastityOS is a modern chastity and FLR (Female-Led Relationship) tracking web a
 ### ☁️ Import/Export JSON
 - Allow users to backup and migrate data manually between devices or browsers via JSON file import/export.
 
+### 📶 Offline Mode
+- Works as a PWA with data cached locally
+- Changes sync to Firebase automatically once you reconnect
+
 ### 🔐 Authentication Options
 - Default anonymous sign-in (no setup required)
 - Optional upgrade to sign in with Google account

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,7 +1,7 @@
 
 
 import { initializeApp, getApps, getApp } from 'firebase/app';
-import { getFirestore } from 'firebase/firestore';
+import { getFirestore, enableIndexedDbPersistence } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
 import { getStorage } from 'firebase/storage';
 
@@ -18,5 +18,11 @@ const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 console.log("✅ Firebase Project ID:", firebaseConfig.projectId);
 
 export const db = getFirestore(app);
+// Enable offline persistence so the app can queue writes and cache reads
+// when the user is offline. This allows the PWA to function smoothly
+// without an internet connection and sync changes once connectivity returns.
+enableIndexedDbPersistence(db).catch((err) => {
+  console.warn('IndexedDB persistence could not be enabled', err);
+});
 export const auth = getAuth(app);
 export const storage = getStorage(app);

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,7 +1,7 @@
 
 
 import { initializeApp, getApps, getApp } from 'firebase/app';
-import { getFirestore, enableIndexedDbPersistence } from 'firebase/firestore';
+import { initializeFirestore, persistentLocalCache, persistentMultipleTabManager } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
 import { getStorage } from 'firebase/storage';
 
@@ -17,12 +17,8 @@ const firebaseConfig = {
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 console.log("✅ Firebase Project ID:", firebaseConfig.projectId);
 
-export const db = getFirestore(app);
-// Enable offline persistence so the app can queue writes and cache reads
-// when the user is offline. This allows the PWA to function smoothly
-// without an internet connection and sync changes once connectivity returns.
-enableIndexedDbPersistence(db).catch((err) => {
-  console.warn('IndexedDB persistence could not be enabled', err);
+export const db = initializeFirestore(app, {
+  localCache: persistentLocalCache({ tabManager: persistentMultipleTabManager() })
 });
 export const auth = getAuth(app);
 export const storage = getStorage(app);


### PR DESCRIPTION
## Summary
- enable `enableIndexedDbPersistence` for Firestore
- document offline mode in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ba602feb4832cacef9faa4388d83a