### PR TITLE
Add light theme option for production

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,7 +42,8 @@ const App = () => {
     showRestoreSessionPrompt,
     loadedSessionData,
     handleRestoreSession,
-    handleDiscardSession
+    handleDiscardSession,
+    themeVariant
   } = chastityOS;
 
   const welcomeState = useWelcome(userId, chastityOS.isAuthReady);
@@ -102,7 +103,11 @@ const App = () => {
   }
 
   const isNightly = import.meta.env.VITE_APP_VARIANT === 'nightly';
-  const themeClass = isNightly ? 'theme-nightly' : 'theme-prod';
+  const themeClass = isNightly
+    ? 'theme-nightly'
+    : themeVariant === 'light'
+      ? 'theme-prod-light'
+      : 'theme-prod';
 
   if (isLoading || welcomeLoading) {
     return <div className="loading-fullscreen">Loading...</div>;

--- a/src/components/settings/DisplaySettingsSection.jsx
+++ b/src/components/settings/DisplaySettingsSection.jsx
@@ -1,7 +1,12 @@
 // src/components/settings/DisplaySettingsSection.jsx
 import React from 'react';
 
-const DisplaySettingsSection = ({ eventDisplayMode, handleSetEventDisplayMode }) => {
+const DisplaySettingsSection = ({
+  eventDisplayMode,
+  handleSetEventDisplayMode,
+  themeVariant,
+  handleSetThemeVariant,
+}) => {
   return (
     <div className="mb-8 p-4 bg-gray-800 border border-blue-700 rounded-lg shadow-sm">
       <h3 className="text-xl font-semibold text-blue-300 mb-4">Display Settings</h3>
@@ -37,6 +42,36 @@ const DisplaySettingsSection = ({ eventDisplayMode, handleSetEventDisplayMode })
       <p className="text-xs text-gray-400 mt-2 text-left">
         Choose 'Kinky' to see all logged sexual events. Choose 'Vanilla' to hide specific "kinky" event types from the log for a more discreet view.
       </p>
+
+      <div className="flex items-center justify-between mt-6">
+        <label htmlFor="themeVariantToggle" className="text-sm font-medium text-purple-300 mr-3">
+          Theme:
+        </label>
+        <div className="flex items-center space-x-4">
+          <label className="flex items-center space-x-2 text-purple-200">
+            <input
+              type="radio"
+              name="themeVariant"
+              value="dark"
+              checked={themeVariant === 'dark'}
+              onChange={() => handleSetThemeVariant('dark')}
+              className="form-radio h-4 w-4 text-blue-600 bg-gray-700 border-gray-600 rounded-full focus:ring-blue-500"
+            />
+            <span>Dark</span>
+          </label>
+          <label className="flex items-center space-x-2 text-purple-200">
+            <input
+              type="radio"
+              name="themeVariant"
+              value="light"
+              checked={themeVariant === 'light'}
+              onChange={() => handleSetThemeVariant('light')}
+              className="form-radio h-4 w-4 text-blue-600 bg-gray-700 border-gray-600 rounded-full focus:ring-blue-500"
+            />
+            <span>Light</span>
+          </label>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/hooks/useDataManagement.js
+++ b/src/hooks/useDataManagement.js
@@ -125,6 +125,7 @@ export function useDataManagement({ userId, isAuthReady, userEmail, settings, se
           keyholderPasswordHash: null,
           isTrackingAllowed: true,
           eventDisplayMode: 'kinky',
+          themeVariant: 'dark',
           rulesText: '',
           publicProfileEnabled: false,
           publicStatsVisibility: {

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -15,6 +15,7 @@ export const useSettings = (userId, isAuthReady) => {
     punishments: [],
     isTrackingAllowed: true,
     eventDisplayMode: 'kinky',
+    themeVariant: 'dark',
     rulesText: '',
     publicProfileEnabled: false,
     publicStatsVisibility: {
@@ -101,6 +102,10 @@ export const useSettings = (userId, isAuthReady) => {
     updateSettings(prev => ({ ...prev, eventDisplayMode: mode }));
   }, [updateSettings]);
 
+  const handleSetThemeVariant = useCallback((variant) => {
+    updateSettings(prev => ({ ...prev, themeVariant: variant }));
+  }, [updateSettings]);
+
   const togglePublicProfileEnabled = useCallback(() => {
     updateSettings(prev => ({ ...prev, publicProfileEnabled: !prev.publicProfileEnabled }));
   }, [updateSettings]);
@@ -177,6 +182,8 @@ export const useSettings = (userId, isAuthReady) => {
     nameMessage,
     eventDisplayMode: settings.eventDisplayMode,
     handleSetEventDisplayMode,
+    themeVariant: settings.themeVariant,
+    handleSetThemeVariant,
     publicProfileEnabled: settings.publicProfileEnabled,
     publicStatsVisibility: settings.publicStatsVisibility,
     togglePublicProfileEnabled,

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,7 @@
 :root, .theme-prod {
   --font-main: 'Cinzel', serif;
 
-  /* --- Primary (Purple) Palette --- */
+  /* --- Primary (Purple) Palette (Dark) --- */
   --color-bg-primary: theme('colors.gray.950');
   --color-bg-secondary: theme('colors.gray.900');
   --color-bg-tertiary: theme('colors.gray.800');
@@ -25,6 +25,25 @@
   --color-button-text: theme('colors.white');
   --color-accent: theme('colors.purple.500');
   --color-focus-ring: theme('colors.purple.400');
+}
+
+/* Light variant for production */
+.theme-prod-light {
+  --font-main: 'Cinzel', serif;
+
+  --color-bg-primary: theme('colors.gray.50');
+  --color-bg-secondary: theme('colors.gray.100');
+  --color-bg-tertiary: theme('colors.gray.200');
+  --color-text-primary: theme('colors.gray.900');
+  --color-text-secondary: theme('colors.gray.800');
+  --color-text-accent: theme('colors.purple.700');
+  --color-border-primary: theme('colors.gray.400');
+  --color-border-accent: theme('colors.purple.600');
+  --color-button-bg: theme('colors.purple.600');
+  --color-button-bg-hover: theme('colors.purple.500');
+  --color-button-text: theme('colors.white');
+  --color-accent: theme('colors.purple.600');
+  --color-focus-ring: theme('colors.purple.500');
 }
 
 .theme-nightly {
@@ -54,7 +73,7 @@
 html, body, #root { @apply h-full m-0 p-0 box-border; }
 *, ::before, ::after { box-sizing: inherit; } 
 :root { @apply leading-normal font-normal text-base; font-synthesis: none; text-rendering: optimizeLegibility; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; color-scheme: light dark; }
-.theme-prod, .theme-nightly { font-family: var(--font-main); background-color: var(--color-bg-primary); color: var(--color-text-primary); }
+.theme-prod, .theme-prod-light, .theme-nightly { font-family: var(--font-main); background-color: var(--color-bg-primary); color: var(--color-text-primary); }
 
 
 /* =============================================


### PR DESCRIPTION
## Summary
- support a `themeVariant` setting in user settings
- allow selecting light or dark theme in Display Settings
- implement `theme-prod-light` CSS vars
- apply the selected variant when rendering

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686beb7dcb38832caf39b0056c95d407