### PR TITLE
Fix cage on time formatting

### DIFF
--- a/src/hooks/useChastitySession.js
+++ b/src/hooks/useChastitySession.js
@@ -3,8 +3,19 @@ import { doc, setDoc, Timestamp, addDoc, onSnapshot, getDoc } from 'firebase/fir
 import { formatElapsedTime } from '../utils';
 import { db } from '../firebase';
 
-// Safe helper for .toDate() usage
-const safeToDate = (v) => (v && typeof v.toDate === 'function') ? v.toDate() : null;
+// Safe helper for various timestamp formats
+const safeToDate = (v) => {
+    if (!v) return null;
+    if (typeof v.toDate === 'function') {
+        const d = v.toDate();
+        return isNaN(d?.getTime?.()) ? null : d;
+    }
+    if (v instanceof Date) {
+        return isNaN(v.getTime()) ? null : v;
+    }
+    const d = new Date(v);
+    return isNaN(d.getTime()) ? null : d;
+};
 
 export const useChastitySession = (
     isAuthReady,

--- a/src/utils/safeToDate.js
+++ b/src/utils/safeToDate.js
@@ -1,1 +1,15 @@
-export const safeToDate = (v) => (v && typeof v.toDate === 'function') ? v.toDate() : null;
+export const safeToDate = (v) => {
+  if (!v) return null;
+  // Firestore Timestamp objects have a toDate() method
+  if (typeof v.toDate === 'function') {
+    const d = v.toDate();
+    return isNaN(d?.getTime?.()) ? null : d;
+  }
+  // If it's already a Date instance, ensure it's valid
+  if (v instanceof Date) {
+    return isNaN(v.getTime()) ? null : v;
+  }
+  // Try to parse strings or numbers into a Date
+  const d = new Date(v);
+  return isNaN(d.getTime()) ? null : d;
+};


### PR DESCRIPTION
## Summary
- handle Date instances and parseable values in `safeToDate`
- update cage session hook with improved `safeToDate`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fbb85d788832c94afbee238b16d49