### PR TITLE
Modernize app styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ChastityOS</title>
     <meta name="theme-color" content="#8b5cf6"> 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -12,11 +12,11 @@ const Header = () => {
   const logo = !isNightly ? productionLogo : nightlyLogo; // Use !isNightly for production
 
   return (
-    <header className="flex items-center gap-4 p-4 bg-theme-bg shadow-md text-theme-text">
-      <img src={logo} alt="ChastityOS Logo" className="h-20 w-20 rounded-lg" />
+    <header className="flex items-center gap-6 p-6 bg-theme-bg/80 backdrop-blur-md rounded-xl shadow-xl text-theme-text">
+      <img src={logo} alt="ChastityOS Logo" className="h-20 w-20 rounded-xl" />
       <div>
-        <h1 className="text-xl font-bold text-theme-text">ChastityOS</h1>
-        <p className="text-sm text-theme-text">{tagline}</p>
+        <h1 className="text-2xl font-bold text-theme-text">ChastityOS</h1>
+        <p className="text-sm text-theme-text opacity-80">{tagline}</p>
       </div>
     </header>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,7 @@
    To change a theme's color, you only need to edit it in one place.
 */
 :root, .theme-prod {
-  --font-main: 'Cinzel', serif;
+  --font-main: 'Inter', sans-serif;
 
   /* --- Primary (Purple) Palette --- */
   --color-bg-primary: theme('colors.gray.950');
@@ -54,7 +54,12 @@
 html, body, #root { @apply h-full m-0 p-0 box-border; }
 *, ::before, ::after { box-sizing: inherit; } 
 :root { @apply leading-normal font-normal text-base; font-synthesis: none; text-rendering: optimizeLegibility; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; color-scheme: light dark; }
-.theme-prod, .theme-nightly { font-family: var(--font-main); background-color: var(--color-bg-primary); color: var(--color-text-primary); }
+.theme-prod, .theme-nightly {
+  font-family: var(--font-main);
+  background: linear-gradient(to bottom, var(--color-bg-primary), var(--color-bg-secondary));
+  color: var(--color-text-primary);
+  min-height: 100%;
+}
 
 
 /* =============================================
@@ -63,7 +68,7 @@ html, body, #root { @apply h-full m-0 p-0 box-border; }
 */
 /* --- Containers & Cards --- */
 .card, .box, .section, .tracker-box, .bordered { background-color: var(--color-bg-secondary); border: 1px solid var(--color-border-primary); color: var(--color-text-primary); }
-.box, .card, .section { @apply p-4 rounded-md; }
+.box, .card, .section { @apply p-6 rounded-xl shadow-lg; }
 .bordered { border-color: var(--color-border-accent); }
 
 /* --- Logo --- */
@@ -77,8 +82,8 @@ p:not([class]), span:not([class]), div:not([class]) { color: var(--color-text-se
 .subpage-title { border-bottom: 1px solid var(--color-border-accent); @apply text-xl font-semibold pb-1; }
 
 /* --- Interactive Elements --- */
-button { background-color: var(--color-button-bg); color: var(--color-button-text); @apply px-4 py-2 rounded transition; }
-button:hover { background-color: var(--color-button-bg-hover); }
+button { background-color: var(--color-button-bg); color: var(--color-button-text); @apply px-4 py-2 rounded-lg shadow transition; }
+button:hover { background-color: var(--color-button-bg-hover); filter: brightness(1.1); }
 button:disabled { @apply opacity-50 cursor-not-allowed; }
 a { color: var(--color-text-accent); @apply transition; }
 a:hover { color: var(--color-text-primary); }


### PR DESCRIPTION
## Summary
- improve default font and container styling
- use gradient background across themes
- refresh header layout
- update fonts in HTML

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686fcc9a80d8832c81c5cd07236f1ff5